### PR TITLE
Fixed the bug caused by not returning the same datatype: in func g_ge…

### DIFF
--- a/src/global.c
+++ b/src/global.c
@@ -113,6 +113,6 @@ int g_setType(int index, lo3_val type) {
 	return 0;
 }
 
-int g_getValue(int index) {
+lo3_val g_getValue(int index) {
 
 }


### PR DESCRIPTION
…tValue() is now set to lo3_val

Consider this issue as finished
Issue 3

Done by: @seesee010
 On branch fix/func-def-name

 Changes to be committed:
	modified:   src/global.c