### PR TITLE
Fixed the bug caused in global.c

### DIFF
--- a/src/global.c
+++ b/src/global.c
@@ -97,14 +97,14 @@ int g_setType(int index, lo3_val type) {
 
 	if (index > 100 || index < 0) {
 		buf.chooseType = -1;
-		lo3_error("setting Type: Wrong Index, you input any out of bounce!", index);
+		lo3_error("setting Type: Wrong Index, you input any out of bounce!", "");
 		return -1;
 
 	}
 
 	if (type.chooseType > 3  || type.chooseType < 0) {
 		buf.chooseType = -1;
-		lo3_error("setting Type: Wrong datatype, what are you doing?", type);
+		lo3_error("setting Type: Wrong datatype, what are you doing?", "");
 		return -1;
 	}
 


### PR DESCRIPTION
lo3_error got the wrong datatype, now it uses "" as param1 [param0][param1]

This could lead to missunderstanding for the user. But while it is really necesary it is ok as it is. From Issue: 4

Done by: @seesee010
 On branch fix/datatype02

 Changes to be committed:
	modified:   src/global.c