### PR TITLE
fix(WARNINGS): now lo3_error msg will work fine and there is no UB an…

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,3 @@
 build/*
 .cache/
+review.md

--- a/src/warnings.c
+++ b/src/warnings.c
@@ -23,6 +23,7 @@ void lo3_error(const char *msg, const char *context) {
 
 	if (msg == NULL || msg[0] == '\0') {
 		lo3_warn("Could not error, because there was no error message for the error", NULL);
+		return;
 	}
 
 	if (context != NULL) {


### PR DESCRIPTION
…y more.

See ISSUE 21 for more informations.

What was the problem?:
There was a return; missing in NULL check! / error check / error way. commit-by: @seesee010

 On branch fix/missing-return01

 Changes to be committed:
	modified:   .gitignore
	modified:   src/warnings.c