### PR TITLE
fix: check for division by zero in exec_div

### DIFF
--- a/src/execute.c
+++ b/src/execute.c
@@ -202,6 +202,11 @@ void exec_div(lo3_val a1, lo3_val a2, char array[2]) {
 		return;
 	}
 
+	if (a2.value.num == 0) {
+		lo3_error("Division by zero", name);
+		return;
+	}
+
 	var_setNum(name, var_getNum(oldVar) / a2.value.num);
 }
 


### PR DESCRIPTION
Emit a runtime error via lo3_error() when the divisor is zero, preventing SIGFPE from crashing the interpreter.

Fixes #20

Generated with [Claude Code](https://claude.ai/code)