### PR TITLE
fix: lo3_error missing return + CI bot loop prevention

### DIFF
--- a/src/global.c
+++ b/src/global.c
@@ -101,16 +101,8 @@ int g_isSet(int index) {
 }
 
 int g_getType(int index) {
-
-	lo3_val buf;
-
-	if (index > 100 || index < 0) {
-		buf.chooseType = -1;
-		return buf;
-	}
-	
-	return  g.value[index].chooseType;
-
+	if (index >= G_SIZE || index < 0) return -1;
+	return g.value[index].chooseType;
 }
 
 int g_setType(int index, lo3_val type) {

--- a/src/global.c
+++ b/src/global.c
@@ -101,7 +101,9 @@ int g_isSet(int index) {
 }
 
 int g_getType(int index) {
-	if (index >= G_SIZE || index < 0) return -1;
+	if (index >= G_SIZE || index < 0) {
+		return -1;
+	}
 	return g.value[index].chooseType;
 }
 

--- a/src/internal/global.h
+++ b/src/internal/global.h
@@ -11,7 +11,7 @@ void g_set(int index, lo3_val value);
 
 int g_isSet(int index);
 
-lo3_val g_getType(int index);
+int g_getType(int index);
 
 int g_setType(int index, lo3_val type);
 


### PR DESCRIPTION
## Summary
- Fixes missing `return` in `lo3_error` NULL check — was causing UB (closes #21)
- Adds `if: github.event.pull_request.user.type != 'Bot'` to `claude-code-review.yml` to prevent infinite loop when Claude bot pushes to a PR

## Test plan
- [ ] Verify `lo3_error(NULL)` returns cleanly without UB
- [ ] Open a PR as bot and confirm `claude-code-review` workflow is skipped
- [ ] Open a PR as human and confirm `claude-code-review` still runs

🤖 Generated with [Claude Code](https://claude.ai/claude-code)