### PR TITLE
fix: resolve type mismatch in exec_in (BUG-01)

### DIFF
--- a/src/execute.c
+++ b/src/execute.c
@@ -268,8 +268,8 @@ void exec_in(lo3_val a1, lo3_val a2, char array[2]) {
 	}
 
 	if (!a2.chooseType) {
-		var_setNum(name, temp);
+		var_setNum(name, temp.value.num);
 	} else {
-		var_setString(name, temp);
+		var_setString(name, temp.value.string);
 	}
 }


### PR DESCRIPTION
Fixes #14

Extract correct fields from lo3_val union before passing to var_setNum and var_setString in exec_in. Previously, the raw lo3_val struct was passed where int and char * were expected, causing compile errors.

Generated with [Claude Code](https://claude.ai/code)