### PR TITLE
fix: reset line and len after free in pars_file getline loop

### DIFF
--- a/src/parsing.c
+++ b/src/parsing.c
@@ -94,6 +94,8 @@ int pars_file(FILE *file) {
 		}
 
 		free(line);
+		line = NULL;
+		len  = 0;
 	}
 	return 0;
 }


### PR DESCRIPTION
Fixes BUG-02: after freeing the line buffer each iteration, reset line=NULL and len=0 so getline allocates a fresh buffer on the next call instead of writing into freed memory.

Closes #15

Generated with [Claude Code](https://claude.ai/code)