### PR TITLE
fix: remove stray space in #include <windows.h>

### DIFF
--- a/src/internal/additional-naming.h
+++ b/src/internal/additional-naming.h
@@ -9,7 +9,7 @@
 
 // sleep(ms) macro
 #ifdef _WIN32
-#include < windows.h>
+#include <windows.h>
 #define ASLEEP(ms) Sleep(ms);
 
 #else // linux


### PR DESCRIPTION
Fixes #31

Removes the stray space between `<` and `windows.h` in `src/internal/additional-naming.h` that caused a preprocessor syntax error on Windows.

Generated with [Claude Code](https://claude.ai/code)