### PR TITLE
fix: zero-initialize arg1/arg2 buffers in pars_file

### DIFF
--- a/src/parsing.c
+++ b/src/parsing.c
@@ -33,7 +33,7 @@ int pars_file(FILE *file) {
 
 	char *line = NULL;
 	size_t len = 0;
-	char arg1[64], arg2[64];
+	char arg1[64] = {0}, arg2[64] = {0};
 	char buff_types[2];
 
 	// todo: make getline avaible on other os


### PR DESCRIPTION
Zero-initialize `arg1` and `arg2` in `pars_file` so that when `sscanf` matches nothing, the buffers contain `\0` instead of uninitialized stack bytes. This turns silent undefined behavior into a clear error via `lo3_error`.

Closes #26

Generated with [Claude Code](https://claude.ai/code)