### PR TITLE
fix(additional-naming.h): now on linux it uses the right additional l…

### DIFF
--- a/src/internal/additional-naming.h
+++ b/src/internal/additional-naming.h
@@ -14,6 +14,6 @@
 
 #else // linux
 #include <unistd.h>
-#define ASLEEP(ms) slee((ms) * 1000) // mic sec -> ms
+#define ASLEEP(ms) usleep((ms) * 1000) // mic sec -> ms
 
 #endif


### PR DESCRIPTION
…ib called usleep instead of 'slee'!