### PR TITLE
fix: correct off-by-one in global array bounds checks

### DIFF
--- a/src/global.c
+++ b/src/global.c
@@ -16,7 +16,7 @@ lo3_val g_get(int index) {
 	char buf[64];
 	snprintf(buf, sizeof(buf), "%d", index);
 
-	if (index > 100 || index < 0) {
+	if (index > G_SIZE - 1 || index < 0) {
 		lo3_error("Could not return any g[index],\n"
 		          "This is Out of bounce!",
 		          buf);
@@ -45,7 +45,7 @@ void g_set(int index, lo3_val value) {
 	char buf[64];
 	snprintf(buf, sizeof(buf), "%d", index);
 
-	if (index > 100 || index < 0) {
+	if (index > G_SIZE - 1 || index < 0) {
 		lo3_error("Could not set any <g>.\n"
 		          "Invalid index for g[]!",
 		          buf);
@@ -89,7 +89,7 @@ int g_isSet(int index) {
 	char buf[64];
 	snprintf(buf, sizeof(buf), "%d", index);
 
-	if (index > 100 || index < 0) {
+	if (index > G_SIZE - 1 || index < 0) {
 		lo3_error("OOB: <g>.\n"
 		          "Invalid index for g[]!",
 		          buf);
@@ -111,7 +111,7 @@ int g_setType(int index, lo3_val type) {
 
 	lo3_val buf;
 
-	if (index > 100 || index < 0) {
+	if (index > G_SIZE - 1 || index < 0) {
 		buf.chooseType = -1;
 		lo3_error("setting Type: Wrong Index, you input any out of bounce!", "");
 		return -1;


### PR DESCRIPTION
Replace `index > 100` with `index > G_SIZE - 1` in all accessor functions in src/global.c so that index 100 is correctly rejected for the 0–99 array.

Fixes #23

Generated with [Claude Code](https://claude.ai/code)