### PR TITLE
FIX(_WIN): fix win compilation problems for platform windows

### DIFF
--- a/src/internal/core.h
+++ b/src/internal/core.h
@@ -15,6 +15,11 @@ int pars_file(FILE *file);
 #define CLR_RESET "\033[0m"
 #define CLR_BOLD "\033[1m"
 
+#if defined(_MSC_VER)
+  typedef long ssize_t;
+
+#endif
+
 #ifdef _WIN32
 ssize_t lo3_getLine(char **lineptr, size_t *n, FILE *stream);
 
@@ -24,11 +29,6 @@ ssize_t lo3_getLine(char **lineptr, size_t *n, FILE *stream);
 #elif __linux__
 #define GETLINE(line, len, file) \
 	(getline((line), (len), (file)) != -1)
-
-#endif
-
-#if defined(_MSC_VER)
-  typedef long ssize_t;
 
 #endif
 

--- a/src/lo3-getLine.c
+++ b/src/lo3-getLine.c
@@ -1,7 +1,6 @@
 #include "./internal/core.h"
 #ifdef _WIN32
 
-typedef long long ssize_t;
 ssize_t lo3_getLine(char **lineptr, size_t *n, FILE *stream) {
 
 	if (lineptr == NULL || n == NULL || stream == NULL) {


### PR DESCRIPTION
There was a bug that happened while compiling on platforms from _WIN. Compilation was mishappening because of: wrong init of ssize_t, which is not iso c standard, only POSIX.

And this code was aimed to achieve to init ssize_t even for _WIN platforms.

But the init had a wrong order in code.
So it could not compile in any matter possible.

This commit should fix the win version, and now allow _WIN platforms to get access to lo3

 On branch main
 Your branch is ahead of 'origin/main' by 1 commit.

 Changes to be committed:
	modified:   src/internal/core.h
	modified:   src/lo3-getLine.c