### PR TITLE
fix: BUG-11 null-terminate var->name after strncpy

### DIFF
--- a/src/var.c
+++ b/src/var.c
@@ -56,7 +56,8 @@ void var_create(const char *name, int type) {
 	lo3_var *var = malloc(sizeof(lo3_var));
 	(void)memset(var, 0, sizeof(lo3_var)); // so var_free works correctly
 
-	(void)strncpy(var->name, name, 64);
+	(void)strncpy(var->name, name, 63);
+	var->name[63] = '\0';
 	var->type = type;
 
 	// save it


### PR DESCRIPTION
Fixes #24

In `var_create`, `strncpy` with count=64 on a 64-byte buffer could fill all bytes without writing a null terminator, causing `strcmp` in `var_find` to read past the buffer (undefined behavior).

The fix copies at most 63 bytes and explicitly sets `var->name[63] = '\0'`, guaranteeing null-termination.

Generated with [Claude Code](https://claude.ai/code)