### PR TITLE
fix: check malloc return value in var_init to prevent NULL dereference

### DIFF
--- a/src/var.c
+++ b/src/var.c
@@ -25,6 +25,10 @@ lo3_varList *list = NULL;
 void var_init(void) {
 
 	list = malloc(sizeof(lo3_varList));
+	if (list == NULL) {
+		lo3_error("List for creating an var could not be created!", "");
+		return;
+	}
 	list->index = 0;
 }
 


### PR DESCRIPTION
Adds a NULL check after malloc in var_init so the interpreter exits cleanly with an error message instead of segfaulting on OOM.

Fixes #22

Generated with [Claude Code](https://claude.ai/code)