### PR TITLE
chore: add lo3_warn for EXITCODE 0 in RET_good case

### DIFF
--- a/src/parsing.c
+++ b/src/parsing.c
@@ -358,6 +358,7 @@ int pars_dispatch(lo3_cmds cmd, lo3_val a1, lo3_val a2, char array[2]) {
 		break;
 
 	case RET_good:
+		lo3_warn("EXITCODE: 0", "");
 		return 0;
 
 	case RET_bad:


### PR DESCRIPTION
Add lo3_warn("EXITCODE: 0", "") before returning in the RET_good case in src/parsing.c.

Closes #64

Generated with [Claude Code](https://claude.ai/code)