### PR TITLE
fix: add NULL guard to var_find to prevent segfault (BUG-23)

### DIFF
--- a/src/var.c
+++ b/src/var.c
@@ -34,6 +34,9 @@ void var_init(void) {
 
 int var_find(const char *name) {
 
+	if (list == NULL) {
+		return -1;
+	}
 	for (int i = 0; i < list->index; i++) {
 		if (strcmp(list->array[i]->name, name) == 0) {
 			return i;


### PR DESCRIPTION
Add a NULL guard at the top of `var_find` to prevent a segfault when `var_init` was never called or `malloc` returned NULL during initialization.

Closes #36

Generated with [Claude Code](https://claude.ai/code)