### PR TITLE
fix: replace atoi with strtol for safe integer parsing

### DIFF
--- a/src/execute.c
+++ b/src/execute.c
@@ -6,6 +6,8 @@
 #include "./internal/global.h"
 #include "./internal/specific-language.h"
 #include "internal/control-flow.h"
+#include <errno.h>
+#include <limits.h>
 #include <string.h>
 
 void exec_new(lo3_val a1, lo3_val a2, char array[2]) {
@@ -23,7 +25,19 @@ void exec_new(lo3_val a1, lo3_val a2, char array[2]) {
 	}
 
 	// get the type
-	unsigned int type = (!a2.chooseType) ? a2.value.num : atoi(a2.value.string);
+	unsigned int type;
+	if (!a2.chooseType) {
+		type = (unsigned int)a2.value.num;
+	} else {
+		char *end;
+		errno = 0;
+		long val = strtol((char *)a2.value.string, &end, 10);
+		if (errno != 0 || end == (char *)a2.value.string || val < 0 || val > INT_MAX) {
+			lo3_error("Invalid type value", (char *)a2.value.string);
+			return;
+		}
+		type = (unsigned int)val;
+	}
 
 	// duplication check
 	if (var_find(name) != -1) {

--- a/src/parsing.c
+++ b/src/parsing.c
@@ -201,12 +201,14 @@ lo3_val pars_resv(char type[64]) {
 	switch (result.type) {
 
 	// find the corresponding type
-	case TYPE_num: {
+	case TYPE_num:
+	{
 		char *end;
 		errno = 0;
+
 		long val = strtol(&type[1], &end, 10);
 		if (errno != 0 || end == &type[1] || val > INT_MAX || val < INT_MIN) {
-			lo3_error("Invalid integer literal", type);
+			lo3_error("<num> is typeof integer!\nBut this value is not!", type);
 			result.value.num = 0;
 			result.chooseType = 0;
 			break;
@@ -216,7 +218,8 @@ lo3_val pars_resv(char type[64]) {
 		break;
 	}
 
-	case TYPE_array: {
+	case TYPE_array:
+	{
 
 		// logic:
 		// *X, lookup X, resolve the value as long as it is a number,
@@ -227,9 +230,10 @@ lo3_val pars_resv(char type[64]) {
 		// *100 -> _Hello
 		char *end;
 		errno = 0;
+
 		long idx = strtol(&type[1], &end, 10);
 		if (errno != 0 || end == &type[1] || idx < 0 || idx > INT_MAX) {
-			lo3_error("Invalid array index", type);
+			lo3_error("Invalid g[] index", type);
 			break;
 		}
 		lo3_val value = g_get((int)idx);

--- a/src/parsing.c
+++ b/src/parsing.c
@@ -10,6 +10,8 @@
 #include "./internal/core.h"
 #include "./internal/global.h"
 #include "./internal/specific-language.h"
+#include <errno.h>
+#include <limits.h>
 #include <stdio.h>
 #include <stdlib.h>
 
@@ -199,13 +201,22 @@ lo3_val pars_resv(char type[64]) {
 	switch (result.type) {
 
 	// find the corresponding type
-	case TYPE_num:
-
-		result.value.num = atoi(&type[1]);
+	case TYPE_num: {
+		char *end;
+		errno = 0;
+		long val = strtol(&type[1], &end, 10);
+		if (errno != 0 || end == &type[1] || val > INT_MAX || val < INT_MIN) {
+			lo3_error("Invalid integer literal", type);
+			result.value.num = 0;
+			result.chooseType = 0;
+			break;
+		}
+		result.value.num = (int)val;
 		result.chooseType = 0;
 		break;
+	}
 
-	case TYPE_array:
+	case TYPE_array: {
 
 		// logic:
 		// *X, lookup X, resolve the value as long as it is a number,
@@ -214,13 +225,20 @@ lo3_val pars_resv(char type[64]) {
 		// not allowed: "*A"
 
 		// *100 -> _Hello
-		int idx = atoi(&type[1]);
-		lo3_val value = g_get(atoi(&type[1]));
+		char *end;
+		errno = 0;
+		long idx = strtol(&type[1], &end, 10);
+		if (errno != 0 || end == &type[1] || idx < 0 || idx > INT_MAX) {
+			lo3_error("Invalid array index", type);
+			break;
+		}
+		lo3_val value = g_get((int)idx);
 
 		result.type = value.chooseType ? TYPE_string : TYPE_num;
 		result.value = value.value;
 		result.chooseType = value.chooseType ? 3 : 0;
 		break;
+	}
 
 	case TYPE_string:
 


### PR DESCRIPTION
Replaces all `atoi` calls with `strtol` and validates results to prevent silent overflow and undefined behavior on out-of-range inputs.

Fixes BUG-22 in:
- `src/parsing.c`: TYPE_num and TYPE_array cases in `pars_resv()`
- `src/execute.c`: variable type parsing in `exec_new()`

Closes #35

Generated with [Claude Code](https://claude.ai/code)