### PR TITLE
chore: remove pars_getToKnowType and buff_types dead code (BUG-19)

### DIFF
--- a/src/execute.c
+++ b/src/execute.c
@@ -8,7 +8,7 @@
 #include "internal/control-flow.h"
 #include <string.h>
 
-void exec_new(lo3_val a1, lo3_val a2, char array[2]) {
+void exec_new(lo3_val a1, lo3_val a2) {
 
 	unsigned char buf[64];
 	unsigned char *name;
@@ -40,7 +40,7 @@ void exec_new(lo3_val a1, lo3_val a2, char array[2]) {
 	var_create(name, type);
 }
 
-void exec_free(lo3_val a1, lo3_val a2, char array[2]) {
+void exec_free(lo3_val a1, lo3_val a2) {
 
 	unsigned char buf[64];
 	unsigned char *name;
@@ -67,7 +67,7 @@ void exec_free(lo3_val a1, lo3_val a2, char array[2]) {
  * what is ok?:
  * string as name, num as name
  */
-void exec_asn(lo3_val a1, lo3_val a2, char array[2]) {
+void exec_asn(lo3_val a1, lo3_val a2) {
 
 	unsigned char buf[64], *name;
 	unsigned char numNameBuf[64];
@@ -96,7 +96,7 @@ void exec_asn(lo3_val a1, lo3_val a2, char array[2]) {
 
 ///// alu /////
 
-void exec_add(lo3_val a1, lo3_val a2, char array[2]) {
+void exec_add(lo3_val a1, lo3_val a2) {
 
 	unsigned char buf[64];
 	unsigned char *name;
@@ -124,7 +124,7 @@ void exec_add(lo3_val a1, lo3_val a2, char array[2]) {
 	var_setNum(name, var_getNum(oldVar) + a2.value.num);
 }
 
-void exec_sub(lo3_val a1, lo3_val a2, char array[2]) {
+void exec_sub(lo3_val a1, lo3_val a2) {
 
 	unsigned char buf[64];
 	unsigned char *name;
@@ -152,7 +152,7 @@ void exec_sub(lo3_val a1, lo3_val a2, char array[2]) {
 	var_setNum(name, var_getNum(oldVar) - a2.value.num);
 }
 
-void exec_mul(lo3_val a1, lo3_val a2, char array[2]) {
+void exec_mul(lo3_val a1, lo3_val a2) {
 
 	unsigned char buf[64];
 	unsigned char *name;
@@ -180,7 +180,7 @@ void exec_mul(lo3_val a1, lo3_val a2, char array[2]) {
 	var_setNum(name, var_getNum(oldVar) * a2.value.num);
 }
 
-void exec_div(lo3_val a1, lo3_val a2, char array[2]) {
+void exec_div(lo3_val a1, lo3_val a2) {
 
 	unsigned char buf[64];
 	unsigned char *name;
@@ -214,7 +214,7 @@ void exec_div(lo3_val a1, lo3_val a2, char array[2]) {
 }
 
 // will cmp and jmp! #?
-void exec_jmp(lo3_val a1, lo3_val a2, char array[2]) {
+void exec_jmp(lo3_val a1, lo3_val a2) {
 
 	char buf[64], buf2[64];
 	char *name, *name2;
@@ -248,14 +248,14 @@ void exec_jmp(lo3_val a1, lo3_val a2, char array[2]) {
 }
 
 // #c
-void exec_call(lo3_val a1, lo3_val a2, char array[2]) {
+void exec_call(lo3_val a1, lo3_val a2) {
 }
 
 // #C - not in use - UB
-void exec_callS(lo3_val a1, lo3_val a2, char array[2]) {
+void exec_callS(lo3_val a1, lo3_val a2) {
 }
 
-void exec_label(lo3_val a1, lo3_val a2, char array[2]) {
+void exec_label(lo3_val a1, lo3_val a2) {
 
 	char buf[64];
 	char *name;
@@ -279,7 +279,7 @@ void exec_label(lo3_val a1, lo3_val a2, char array[2]) {
 	cf_addLabel(name, lastLineOffset);
 }
 
-void exec_out(lo3_val a1, lo3_val a2, char array[2]) {
+void exec_out(lo3_val a1, lo3_val a2) {
 
 	unsigned char buf[64];
 	unsigned char *name;
@@ -294,7 +294,7 @@ void exec_out(lo3_val a1, lo3_val a2, char array[2]) {
 	printf("%63s\n", name);
 }
 
-void exec_in(lo3_val a1, lo3_val a2, char array[2]) {
+void exec_in(lo3_val a1, lo3_val a2) {
 
 	unsigned char buf[64] = {0}; // privides buf not initing
 	unsigned char *res;
@@ -332,7 +332,7 @@ void exec_in(lo3_val a1, lo3_val a2, char array[2]) {
 }
 
 // compare num == num, if true -> g[0] = 1, else g[0] = 0;!!!
-void exec_cmp(lo3_val a1, lo3_val a2, char array[2]) {
+void exec_cmp(lo3_val a1, lo3_val a2) {
 
 	if (a1.chooseType || a2.chooseType) {
 		lo3_error("You can not compare char*'s,\n"
@@ -355,7 +355,7 @@ void exec_cmp(lo3_val a1, lo3_val a2, char array[2]) {
 }
 
 // compare num < num, if true -> g[0] = 1, else g[0] = 0;!!!
-void exec_small(lo3_val a1, lo3_val a2, char array[2]) {
+void exec_small(lo3_val a1, lo3_val a2) {
 
 	if (a1.chooseType || a2.chooseType) {
 		lo3_error("You can not compare char*'s,\n"
@@ -378,7 +378,7 @@ void exec_small(lo3_val a1, lo3_val a2, char array[2]) {
 }
 
 // compare num > num, if true -> g[0] = 1, else g[0] = 0;!!!
-void exec_big(lo3_val a1, lo3_val a2, char array[2]) {
+void exec_big(lo3_val a1, lo3_val a2) {
 
 	if (a1.chooseType || a2.chooseType) {
 		lo3_error("You can not compare char*'s,\n"

--- a/src/internal/specific-language.h
+++ b/src/internal/specific-language.h
@@ -41,23 +41,22 @@ typedef enum {
 
 ////////// parser //////////
 lo3_val pars_resv(char type[64]);
-int pars_dispatch(lo3_cmds cmd, lo3_val a1, lo3_val a2, char array[2]);
-int pars_getToKnowType(char buffer[2], lo3_val val1, lo3_val val2);
+int pars_dispatch(lo3_cmds cmd, lo3_val a1, lo3_val a2);
 
 // execute func
-void exec_new(lo3_val a1, lo3_val a2, char array[2]);
-void exec_asn(lo3_val a1, lo3_val a2, char array[2]);
-void exec_add(lo3_val a1, lo3_val a2, char array[2]);
-void exec_sub(lo3_val a1, lo3_val a2, char array[2]);
-void exec_mul(lo3_val a1, lo3_val a2, char array[2]);
-void exec_div(lo3_val a1, lo3_val a2, char array[2]);
-void exec_jmp(lo3_val a1, lo3_val a2, char array[2]);
-void exec_call(lo3_val a1, lo3_val a2, char array[2]);
-void exec_callS(lo3_val a1, lo3_val a2, char array[2]);
-void exec_label(lo3_val a1, lo3_val a2, char array[2]);
-void exec_out(lo3_val a1, lo3_val a2, char array[2]);
-void exec_in(lo3_val a1, lo3_val a2, char array[2]);
-void exec_free(lo3_val a1, lo3_val a2, char array[2]);
-void exec_cmp(lo3_val a1, lo3_val a2, char array[2]);
-void exec_small(lo3_val a1, lo3_val a2, char array[2]);
-void exec_big(lo3_val a1, lo3_val a2, char array[2]);
+void exec_new(lo3_val a1, lo3_val a2);
+void exec_asn(lo3_val a1, lo3_val a2);
+void exec_add(lo3_val a1, lo3_val a2);
+void exec_sub(lo3_val a1, lo3_val a2);
+void exec_mul(lo3_val a1, lo3_val a2);
+void exec_div(lo3_val a1, lo3_val a2);
+void exec_jmp(lo3_val a1, lo3_val a2);
+void exec_call(lo3_val a1, lo3_val a2);
+void exec_callS(lo3_val a1, lo3_val a2);
+void exec_label(lo3_val a1, lo3_val a2);
+void exec_out(lo3_val a1, lo3_val a2);
+void exec_in(lo3_val a1, lo3_val a2);
+void exec_free(lo3_val a1, lo3_val a2);
+void exec_cmp(lo3_val a1, lo3_val a2);
+void exec_small(lo3_val a1, lo3_val a2);
+void exec_big(lo3_val a1, lo3_val a2);

--- a/src/parsing.c
+++ b/src/parsing.c
@@ -97,12 +97,6 @@ parsing:
 		lo3_val a1 = pars_resv(arg1);
 		lo3_val a2 = pars_resv(arg2);
 
-		// todo:
-		// parse that prefix away.
-		//
-		// ///// More Information: /////
-		// here the program should parse the prefix, for example: '$' away.
-		// So the Exec dont have to do that.
 		signed int returnVal = pars_dispatch(cmds, a1, a2);
 
 		if (returnVal != -1) {

--- a/src/parsing.c
+++ b/src/parsing.c
@@ -41,7 +41,6 @@ int pars_file(FILE *file) {
 	char *line = NULL;
 	size_t len = 0;
 	char arg1[64] = {0}, arg2[64] = {0};
-	unsigned char buff_types[2];
 
 	int pos0 = ftell(file);
 
@@ -99,19 +98,12 @@ parsing:
 		lo3_val a2 = pars_resv(arg2);
 
 		// todo:
-		// delete the func pars_getToKnowType(...)
-		//
-		// ///// More Information /////
-		// this func is not used anymore, because buff_types is ether.
-		(void)pars_getToKnowType(buff_types, a1, a2);
-
-		// todo:
 		// parse that prefix away.
 		//
 		// ///// More Information: /////
 		// here the program should parse the prefix, for example: '$' away.
 		// So the Exec dont have to do that.
-		signed int returnVal = pars_dispatch(cmds, a1, a2, buff_types);
+		signed int returnVal = pars_dispatch(cmds, a1, a2);
 
 		if (returnVal != -1) {
 			free(line);
@@ -134,57 +126,6 @@ parsing:
 			lo3_error("Could not find the label, did you misspell it???", "");
 			return -1;
 		}
-	}
-	return 0;
-}
-
-int pars_getToKnowType(char buffer[2], lo3_val val1, lo3_val val2) {
-
-	/* types:
-	 * 00|xx: num
-	 * 01|xx: var
-	 * 10|xx: array
-	 * 11|xx: string
-	 *
-	 * Both sides have that syntax.
-	 */
-
-	unsigned char num[2];
-
-	lo3_types possibleType[] = {val1.type, val2.type};
-	lo3_val values[] = {val1, val2};
-
-	// todo:
-	// num[] could be deleted
-	//
-	// ///// More Information /////
-	// Deleted because num[] is an additional array, which is not needed...
-	// simply using buffer[] direct instead of num[].
-	for (int i = 0; i < 2; i++) {
-		switch (possibleType[i]) {
-
-		case '$':
-			num[i] = 0b0;
-			break;
-
-		case '%':
-			num[i] = 0b01;
-			break;
-
-		case '*':
-			num[i] = 0b10;
-			break;
-
-		case '_':
-			num[i] = 0b11;
-			break;
-
-		default:
-			lo3_error("Invalid Type of <STRING> found!", values[i].value.string);
-			return 1;
-			break;
-		}
-		buffer[i] = num[i];
 	}
 	return 0;
 }
@@ -270,19 +211,13 @@ lo3_val pars_resv(char type[64]) {
 	return result;
 }
 
-// todo:
-// char array[2] should be deleted in every exec_...
-//
-// ///// More Information /////
-// Now array is very useless and not very helping. Now lo3_val has chooseType to choose its
-// type.
-int pars_dispatch(lo3_cmds cmd, lo3_val a1, lo3_val a2, char array[2]) {
+int pars_dispatch(lo3_cmds cmd, lo3_val a1, lo3_val a2) {
 
 	if (rush) {
 
 		switch (cmd) {
 		case CNT_label:
-			exec_label(a1, a2, array);
+			exec_label(a1, a2);
 			break;
 
 		default:
@@ -296,65 +231,65 @@ int pars_dispatch(lo3_cmds cmd, lo3_val a1, lo3_val a2, char array[2]) {
 
 	case BSC_asn:
 
-		exec_asn(a1, a2, array);
+		exec_asn(a1, a2);
 		break;
 
 	case ALU_add:
 
-		exec_add(a1, a2, array);
+		exec_add(a1, a2);
 		break;
 
 	case ALU_sub:
 
-		exec_sub(a1, a2, array);
+		exec_sub(a1, a2);
 		break;
 
 	case ALU_mul:
 
-		exec_mul(a1, a2, array);
+		exec_mul(a1, a2);
 		break;
 
 	case ALU_div:
 
-		exec_div(a1, a2, array);
+		exec_div(a1, a2);
 		break;
 
 	case CNT_jmp:
 
-		exec_jmp(a1, a2, array);
+		exec_jmp(a1, a2);
 		break;
 
 	case CNT_call:
 
-		exec_call(a1, a2, array);
+		exec_call(a1, a2);
 		break;
 
 	case CNT_callS:
 
-		exec_callS(a1, a2, array);
+		exec_callS(a1, a2);
 		break;
 
 	case CNT_label:
 
-		exec_label(a1, a2, array);
+		exec_label(a1, a2);
 		break;
 
 	case CNT_new:
-		exec_new(a1, a2, array);
+		exec_new(a1, a2);
 		break;
 
 	case CNT_free:
-		exec_free(a1, a2, array);
+		exec_free(a1, a2);
 		break;
 
 	case STM_out:
 
-		exec_out(a1, a2, array);
+		exec_out(a1, a2);
 		break;
 
 	case STM_in:
 
-		exec_in(a1, a2, array);
+		exec_in(a1, a2);
 		break;
 
 	case RET_good:
@@ -365,15 +300,15 @@ int pars_dispatch(lo3_cmds cmd, lo3_val a1, lo3_val a2, char array[2]) {
 
 	case CNT_cmp:
 
-		exec_cmp(a1, a2, array);
+		exec_cmp(a1, a2);
 		break;
 
 	case CNT_small:
-		exec_small(a1, a2, array);
+		exec_small(a1, a2);
 		break;
 
 	case CNT_big:
-		exec_big(a1, a2, array);
+		exec_big(a1, a2);
 		break;
 
 	default:


### PR DESCRIPTION
Removes dead code flagged by source TODOs: pars_getToKnowType function, its declaration, the buff_types local, and the char array[2] parameter from pars_dispatch and all exec_* functions.

Closes #32

Generated with [Claude Code](https://claude.ai/code)