### PR TITLE
fix: correct argument counts in unit tests

### DIFF
--- a/test/unit/test_execute.c
+++ b/test/unit/test_execute.c
@@ -15,8 +15,6 @@
 
 FILE *openFile = NULL;
 
-static char dummy[2] = {0, 0};
-
 static lo3_val nval(int n) {
     lo3_val v;
     v.type = TYPE_num;
@@ -47,103 +45,103 @@ void tearDown(void) {
 // ── exec_cmp ──────────────────────────────────────────────────────────────────
 
 void test_exec_cmp_equal_sets_true(void) {
-    exec_cmp(nval(5), nval(5), dummy);
+    exec_cmp(nval(5), nval(5));
     TEST_ASSERT_EQUAL_INT(TRUE, g_getNum(0));
 }
 
 void test_exec_cmp_not_equal_sets_false(void) {
-    exec_cmp(nval(3), nval(7), dummy);
+    exec_cmp(nval(3), nval(7));
     TEST_ASSERT_EQUAL_INT(FALSE, g_getNum(0));
 }
 
 void test_exec_cmp_zero_equal(void) {
-    exec_cmp(nval(0), nval(0), dummy);
+    exec_cmp(nval(0), nval(0));
     TEST_ASSERT_EQUAL_INT(TRUE, g_getNum(0));
 }
 
 void test_exec_cmp_negative_equal(void) {
-    exec_cmp(nval(-4), nval(-4), dummy);
+    exec_cmp(nval(-4), nval(-4));
     TEST_ASSERT_EQUAL_INT(TRUE, g_getNum(0));
 }
 
 void test_exec_cmp_negative_not_equal(void) {
-    exec_cmp(nval(-1), nval(1), dummy);
+    exec_cmp(nval(-1), nval(1));
     TEST_ASSERT_EQUAL_INT(FALSE, g_getNum(0));
 }
 
 void test_exec_cmp_string_arg_no_crash(void) {
     // lo3_error is called; result is undefined but must not crash
-    exec_cmp(sval("a"), nval(0), dummy);
+    exec_cmp(sval("a"), nval(0));
 }
 
 // ── exec_small ────────────────────────────────────────────────────────────────
 
 void test_exec_small_less_than_sets_true(void) {
-    exec_small(nval(2), nval(5), dummy);
+    exec_small(nval(2), nval(5));
     TEST_ASSERT_EQUAL_INT(TRUE, g_getNum(0));
 }
 
 void test_exec_small_equal_sets_false(void) {
-    exec_small(nval(5), nval(5), dummy);
+    exec_small(nval(5), nval(5));
     TEST_ASSERT_EQUAL_INT(FALSE, g_getNum(0));
 }
 
 void test_exec_small_greater_sets_false(void) {
-    exec_small(nval(8), nval(3), dummy);
+    exec_small(nval(8), nval(3));
     TEST_ASSERT_EQUAL_INT(FALSE, g_getNum(0));
 }
 
 void test_exec_small_negative_less_sets_true(void) {
-    exec_small(nval(-5), nval(0), dummy);
+    exec_small(nval(-5), nval(0));
     TEST_ASSERT_EQUAL_INT(TRUE, g_getNum(0));
 }
 
 void test_exec_small_string_arg_no_crash(void) {
-    exec_small(sval("x"), nval(0), dummy);
+    exec_small(sval("x"), nval(0));
 }
 
 // ── exec_big ──────────────────────────────────────────────────────────────────
 
 void test_exec_big_greater_than_sets_true(void) {
-    exec_big(nval(9), nval(3), dummy);
+    exec_big(nval(9), nval(3));
     TEST_ASSERT_EQUAL_INT(TRUE, g_getNum(0));
 }
 
 void test_exec_big_equal_sets_false(void) {
-    exec_big(nval(4), nval(4), dummy);
+    exec_big(nval(4), nval(4));
     TEST_ASSERT_EQUAL_INT(FALSE, g_getNum(0));
 }
 
 void test_exec_big_less_sets_false(void) {
-    exec_big(nval(1), nval(10), dummy);
+    exec_big(nval(1), nval(10));
     TEST_ASSERT_EQUAL_INT(FALSE, g_getNum(0));
 }
 
 void test_exec_big_negative_greater_sets_true(void) {
-    exec_big(nval(0), nval(-1), dummy);
+    exec_big(nval(0), nval(-1));
     TEST_ASSERT_EQUAL_INT(TRUE, g_getNum(0));
 }
 
 void test_exec_big_string_arg_no_crash(void) {
-    exec_big(nval(0), sval("y"), dummy);
+    exec_big(nval(0), sval("y"));
 }
 
 // ── exec_label ────────────────────────────────────────────────────────────────
 
 void test_exec_label_registers_label(void) {
-    exec_label(sval("myLabel"), nval(0), dummy);
+    exec_label(sval("myLabel"), nval(0));
     TEST_ASSERT_TRUE(cf_findLabel("myLabel") >= 0);
 }
 
 void test_exec_label_duplicate_no_crash(void) {
     // second call triggers lo3_error but must not crash
-    exec_label(sval("dupLabel"), nval(0), dummy);
-    exec_label(sval("dupLabel"), nval(0), dummy);
+    exec_label(sval("dupLabel"), nval(0));
+    exec_label(sval("dupLabel"), nval(0));
     TEST_ASSERT_TRUE(cf_findLabel("dupLabel") >= 0);
 }
 
 void test_exec_label_numeric_name(void) {
-    exec_label(nval(42), nval(0), dummy);
+    exec_label(nval(42), nval(0));
     TEST_ASSERT_TRUE(cf_findLabel("42") >= 0);
 }
 

--- a/test/unit/test_parsing.c
+++ b/test/unit/test_parsing.c
@@ -160,16 +160,14 @@ void test_pars_isFileValid_nonexistent_file(void) {
 
 void test_pars_dispatch_ret_good_returns_zero(void) {
     lo3_val dummy = {0};
-    char arr[2] = {0};
     // RET_good = '0' character — should return 0
-    int r = pars_dispatch(RET_good, dummy, dummy, arr);
+    int r = pars_dispatch(RET_good, dummy, dummy);
     TEST_ASSERT_EQUAL_INT(0, r);
 }
 
 void test_pars_dispatch_ret_bad_returns_one(void) {
     lo3_val dummy = {0};
-    char arr[2] = {0};
-    int r = pars_dispatch(RET_bad, dummy, dummy, arr);
+    int r = pars_dispatch(RET_bad, dummy, dummy);
     TEST_ASSERT_EQUAL_INT(1, r);
 }
 
@@ -178,8 +176,7 @@ void test_pars_dispatch_exec_new_returns_minus1(void) {
     unsigned char name[] = "dispatch_var";
     a1.type = TYPE_string; a1.chooseType = 3; a1.value.string = name;
     a2.type = TYPE_num;    a2.chooseType = 0; a2.value.num    = 0;
-    char arr[2] = {0};
-    int r = pars_dispatch(CNT_new, a1, a2, arr);
+    int r = pars_dispatch(CNT_new, a1, a2);
     TEST_ASSERT_EQUAL_INT(-1, r); // exec functions return -1 via dispatch
     TEST_ASSERT_TRUE(var_find("dispatch_var") >= 0);
 }


### PR DESCRIPTION
Remove spurious extra arguments from exec_cmp/small/big/label calls in test_execute.c and from pars_dispatch calls in test_parsing.c so they match the actual function signatures.

Fixes #95

Generated with [Claude Code](https://claude.ai/code)