### PR TITLE
refactor: apply coding guidelines across all source files

### DIFF
--- a/src/control-flow.c
+++ b/src/control-flow.c
@@ -51,7 +51,7 @@ int cf_getPos(const char *name) {
 // important: this func should only be used intern, because it's not error proof
 void cf_setCursorPos(const int i) {
 
-	fseek(openFile, i, SEEK_SET);
+	(void)fseek(openFile, i, SEEK_SET);
 }
 
 int cf_getCursorPos(void) {

--- a/src/execute.c
+++ b/src/execute.c
@@ -20,7 +20,8 @@ void exec_new(lo3_val a1, lo3_val a2) {
 		snprintf(buf, sizeof(buf), "%d", a1.value.num);
 		lo3_warn("Are you sure you want to set the name as a number?", buf);
 		name = buf;
-	} else {
+	}
+	else {
 		name = a1.value.string;
 	}
 
@@ -28,7 +29,8 @@ void exec_new(lo3_val a1, lo3_val a2) {
 	unsigned int type;
 	if (!a2.chooseType) {
 		type = (unsigned int)a2.value.num;
-	} else {
+	}
+	else {
 		char *end;
 		errno = 0;
 		long val = strtol((char *)a2.value.string, &end, 10);
@@ -64,7 +66,8 @@ void exec_free(lo3_val a1, lo3_val a2) {
 		lo3_warn("Are you sure you want to delete some var called:\nDoing it anyways... ",
 		         buf);
 		name = buf;
-	} else {
+	}
+	else {
 		name = a1.value.string;
 	}
 
@@ -90,7 +93,8 @@ void exec_asn(lo3_val a1, lo3_val a2) {
 		snprintf(buf, sizeof(buf), "%d", a1.value.num);
 		name = buf;
 
-	} else {
+	}
+	else {
 		name = a1.value.string;
 	}
 
@@ -103,7 +107,8 @@ void exec_asn(lo3_val a1, lo3_val a2) {
 	// set
 	if (!a2.chooseType) {
 		var_setNum(name, a2.value.num);
-	} else {
+	}
+	else {
 		var_setString(name, a2.value.string);
 	}
 }
@@ -119,7 +124,8 @@ void exec_add(lo3_val a1, lo3_val a2) {
 		snprintf(buf, sizeof(buf), "%d", a1.value.num);
 		name = buf;
 
-	} else {
+	}
+	else {
 		name = a1.value.string;
 	}
 
@@ -147,7 +153,8 @@ void exec_sub(lo3_val a1, lo3_val a2) {
 		snprintf(buf, sizeof(buf), "%d", a1.value.num);
 		name = buf;
 
-	} else {
+	}
+	else {
 		name = a1.value.string;
 	}
 
@@ -175,7 +182,8 @@ void exec_mul(lo3_val a1, lo3_val a2) {
 		snprintf(buf, sizeof(buf), "%d", a1.value.num);
 		name = buf;
 
-	} else {
+	}
+	else {
 		name = a1.value.string;
 	}
 
@@ -203,7 +211,8 @@ void exec_div(lo3_val a1, lo3_val a2) {
 		snprintf(buf, sizeof(buf), "%d", a1.value.num);
 		name = buf;
 
-	} else {
+	}
+	else {
 		name = a1.value.string;
 	}
 
@@ -237,7 +246,8 @@ void exec_jmp(lo3_val a1, lo3_val a2) {
 	if (!a1.chooseType) {
 		(void)snprintf(buf, sizeof(buf), "%d", a1.value.num);
 		name = buf;
-	} else {
+	}
+	else {
 		name = a1.value.string;
 	}
 
@@ -277,7 +287,8 @@ void exec_label(lo3_val a1, lo3_val a2) {
 	if (!a1.chooseType) {
 		(void)snprintf(buf, sizeof(buf), "%d", a1.value.num);
 		name = buf;
-	} else {
+	}
+	else {
 		name = a1.value.string;
 	}
 
@@ -301,7 +312,8 @@ void exec_out(lo3_val a1, lo3_val a2) {
 	if (!a1.chooseType) {
 		(void)snprintf(buf, sizeof(buf), "%d", a1.value.num);
 		name = buf;
-	} else {
+	}
+	else {
 		name = a1.value.string;
 	}
 
@@ -334,13 +346,15 @@ void exec_in(lo3_val a1, lo3_val a2) {
 	if (!a1.chooseType) {
 		snprintf(numNameBuf, sizeof(numNameBuf), "%d", a1.value.num);
 		name = numNameBuf;
-	} else {
+	}
+	else {
 		name = a1.value.string;
 	}
 
 	if (!a2.chooseType) {
 		var_setNum(name, temp.value.num);
-	} else {
+	}
+	else {
 		var_setString(name, temp.value.string);
 	}
 }
@@ -350,7 +364,7 @@ void exec_cmp(lo3_val a1, lo3_val a2) {
 
 	if (a1.chooseType || a2.chooseType) {
 		lo3_error("You can not compare char*'s,\n"
-	    "Please use the coresponding std-func!, from {string.c}", "");
+			"Please use the coresponding std-func!, from {string.c}", "");
 		return;
 	}
 
@@ -373,7 +387,7 @@ void exec_small(lo3_val a1, lo3_val a2) {
 
 	if (a1.chooseType || a2.chooseType) {
 		lo3_error("You can not compare char*'s,\n"
-	    "Please use the coresponding std-func!, from {string.c}", "");
+			"Please use the coresponding std-func!, from {string.c}", "");
 		return;
 	}
 
@@ -396,7 +410,7 @@ void exec_big(lo3_val a1, lo3_val a2) {
 
 	if (a1.chooseType || a2.chooseType) {
 		lo3_error("You can not compare char*'s,\n"
-	    "Please use the coresponding std-func!, from {string.c}", "");
+			"Please use the coresponding std-func!, from {string.c}", "");
 		return;
 	}
 

--- a/src/global.c
+++ b/src/global.c
@@ -29,8 +29,6 @@ lo3_val g_get(int index) {
 }
 
 // todo: add the way to check for isSet[index]
-// NOTE: it could be fixed already ....!
-//
 // ///// More Informations /////
 // there is a array called isSet, the purpose is to
 // check if any of the indexes are already set or not set at all.
@@ -60,7 +58,6 @@ void g_set(int index, lo3_val value) {
 }
 
 // todo: add the way to check for isSet[index]
-//
 // ///// More Informations /////
 // there is a array called isSet, the purpose is to
 // check if any of the indexes are already set or not set at all.
@@ -118,8 +115,6 @@ int g_setType(int index, lo3_val type) {
 }
 
 // todo: inpliment g_getValue
-// NOTE: WIP — not implemented yet!
-//
 // ///// More Informations /////
 // This function should return the lo3_val stored at g.value[index].
 // For now it returns a placeholder (chooseType = -1) to avoid
@@ -131,12 +126,14 @@ lo3_val g_getValue(int index) {
 	return placeholder;
 }
 
-// NOTE: this func should not be used by any seriously codebase, this func
-// can selfish not fully cover if it is OOB or if the value is even an integer.
-// PLEASE:
-// Consider using the func g_getValue() even if you then must check which type it is by yourself!
-// if you really want to use this func, use the MACRO called G_GETV(index), this will be replaced by
-// g_getNum(...) or g_getString(...)
+/*
+ * NOTE: this func should not be used by any seriously codebase, this func
+ * can selfish not fully cover if it is OOB or if the value is even an integer.
+ * PLEASE:
+ * Consider using the func g_getValue() even if you then must check which type it is by yourself!
+ * if you really want to use this func, use the MACRO called G_GETV(index), this will be replaced by
+ * g_getNum(...) or g_getString(...)
+ */
 int g_getNum(int index) {
 	if (index >= G_SIZE || index < 0) {
 		return -1; // could also eventually be data!!!
@@ -145,12 +142,14 @@ int g_getNum(int index) {
 	return g.value[index].value.num;
 }
 
-// NOTE: this func should not be used by any seriously codebase, this func
-// can selfish not fully cover if it is OOB or if the value is even a String.
-// PLEASE:
-// Consider using the func g_getValue() even if you then must check which type it is by yourself!
-// if you really want to use this func, use the MACRO called G_GETV(index), this will be replaced by
-// g_getNum(...) or g_getString(...) !!!
+/*
+ * NOTE: this func should not be used by any seriously codebase, this func
+ * can selfish not fully cover if it is OOB or if the value is even a String.
+ * PLEASE:
+ * Consider using the func g_getValue() even if you then must check which type it is by yourself!
+ * if you really want to use this func, use the MACRO called G_GETV(index), this will be replaced by
+ * g_getNum(...) or g_getString(...) !!!
+ */
 char *g_getString(int index) {
 	if (index >= G_SIZE || index < 0) {
 		return "_error"; // could also eventually be data!!!
@@ -191,9 +190,7 @@ void g_fasterInit(char *line) {
 			ip++; // skip ','
 		}
 
-		// todo:
-		// this code should really use g_setValue(), but by now it is not avaible!
-		//
+		// todo: this code should really use g_setValue(), but by now it is not avaible!
 		// ///// More Informations /////
 		// this func should use g_setValue() so global itself will carry about formating
 		// every tiny bit right. And this code wont use lo3_val value !!! After it

--- a/src/internal/bare-define.h
+++ b/src/internal/bare-define.h
@@ -10,7 +10,7 @@ typedef enum {
 } lo3_types;
 
 typedef union {
-	 signed int num;
+	signed int num;
 	unsigned char *string;
 	double numD;
 } lo3_value;

--- a/src/internal/cf-define.h
+++ b/src/internal/cf-define.h
@@ -1,3 +1,5 @@
+#pragma once
+
 #include <stdio.h>
 
 ///// main.c /////

--- a/src/main.c
+++ b/src/main.c
@@ -17,13 +17,12 @@ int main(int argc, char *argv[]) {
 	FILE *file;
 	if (pars_isFileValid(argv[1], &file)) {
 		lo3_error("Could not load the coresponding file!", argv[1]);
-		(void)(fclose(file));
+		(void)fclose(file);
 		return 1;
 	}
 
 	openFile = file;
-	// TODO:
-	// let the system(cpp file) run before
+	// todo: let the system(cpp file) run before
 	// ///// More Informations /////
 	// Only run that call if file ends with .LO3 or the --cpp flag is set!
 	

--- a/src/parsing.c
+++ b/src/parsing.c
@@ -30,7 +30,7 @@ int pars_isFileValid(char *name, FILE **file) {
 
 	if (len < 4 || strcmp(&name[len - 4], ".lo3") != 0) {
 		lo3_error("File must end with .lo3\n", name);
-		(void)(fclose((*file)));
+		(void)fclose(*file);
 		return -1;
 	}
 	return 0;
@@ -45,8 +45,7 @@ int pars_file(FILE *file) {
 	int pos0 = ftell(file);
 
 	// todo: make getline avaible on other os
-	//
-	// ///// MORE INFORMATIONS /////
+	// ///// More Informations /////
 	// getline is not a c standardized lib and therefore should be defined somewhere else.
 	// Ways to solve that problem:
 	// - Create a getline MACRO and use that here
@@ -64,7 +63,8 @@ parsing:
 			if (line[1] == '.') {
 				LO3_STARTING_LINE = line[2];
 
-			} else if (line[1] == '{') {
+			}
+			else if (line[1] == '{') {
 				// @{1:$10,10:_Hello}
 				// index | type | word
 
@@ -116,7 +116,8 @@ parsing:
 			isWarped = TRUE;
 			goto parsing;
 
-		} else {
+		}
+		else {
 			lo3_error("Could not find the label, did you misspell it???", "");
 			return -1;
 		}

--- a/src/var.c
+++ b/src/var.c
@@ -118,8 +118,9 @@ void var_free(const char *name) {
 void var_freeAll(void) {
 
 	for (int i = 0; i < list->index; i++) {
-		if (list->array[i]->type == 3)
+		if (list->array[i]->type == 3) {
 			free(list->array[i]->value.string);
+		}
 		free(list->array[i]);
 	}
 
@@ -139,7 +140,8 @@ void var_setNum(const char *name, int num) {
 	if (list->array[i]->type == 3) {
 		lo3_error("Can not set <var> to any num, because its type is set to string!", name);
 		return;
-	} else {
+	}
+	else {
 		list->array[i]->value.num = num;
 	}
 }


### PR DESCRIPTION
- Add (void) cast to fseek() in control-flow.c
- Fix all } else { to } \n else { per brace style
- Convert multi-line // comment blocks to /* */ in global.c
- Fix todo comment format (lowercase, remove extra lines before divider)
- Add missing braces to single-statement if body in var.c
- Remove extra parens around fclose() calls in main.c and parsing.c
- Add #pragma once to cf-define.h
- Fix tab+space mixed indentation in bare-define.h
- Fix string continuation indentation in execute.c (spaces → tabs)
- Fix MORE INFORMATIONS → More Informations in parsing.c todo