### PR TITLE
feat: add syscall cmd (#s) for v0.3.0

### DIFF
--- a/future/v0.3.0/src/execute.c
+++ b/future/v0.3.0/src/execute.c
@@ -1,0 +1,441 @@
+// Copyright (c) 2026 seesee010
+// Read the License file for more informations about the license.
+
+#include "./internal/bare-var.h"
+#include "./internal/core.h"
+#include "./internal/global.h"
+#include "./internal/specific-language.h"
+#include "internal/control-flow.h"
+#include <errno.h>
+#include <limits.h>
+#include <string.h>
+
+#ifdef __linux__
+#include <sys/syscall.h>
+#include <unistd.h>
+#endif
+
+void exec_new(lo3_val a1, lo3_val a2) {
+
+	unsigned char buf[64];
+	unsigned char *name;
+
+	if (!a1.chooseType) {
+
+		snprintf(buf, sizeof(buf), "%d", a1.value.num);
+		lo3_warn("Are you sure you want to set the name as a number?", buf);
+		name = buf;
+	} else {
+		name = a1.value.string;
+	}
+
+	// get the type
+	unsigned int type;
+	if (!a2.chooseType) {
+		type = (unsigned int)a2.value.num;
+	} else {
+		char *end;
+		errno = 0;
+		long val = strtol((char *)a2.value.string, &end, 10);
+		if (errno != 0 || end == (char *)a2.value.string || val < 0 || val > INT_MAX) {
+			lo3_error("Invalid type value", (char *)a2.value.string);
+			return;
+		}
+		type = (unsigned int)val;
+	}
+
+	// duplication check
+	if (var_find(name) != -1) {
+		lo3_error("Variable already exists!", name);
+		return;
+	}
+
+	if (type != 0 && type != 3) {
+
+		snprintf(buf, sizeof(buf), "%d", type);
+		lo3_warn("Variable type might not be num or string!", buf);
+	}
+
+	var_create(name, type);
+}
+
+void exec_free(lo3_val a1, lo3_val a2) {
+
+	unsigned char buf[64];
+	unsigned char *name;
+
+	if (!a1.chooseType) {
+		snprintf(buf, sizeof(buf), "%d", a1.value.num);
+		lo3_warn("Are you sure you want to delete some var called:\nDoing it anyways... ",
+		         buf);
+		name = buf;
+	} else {
+		name = a1.value.string;
+	}
+
+	// ignore arg1
+
+	var_free(name);
+}
+
+/*
+ * algo:
+ * if the type of a1 is the same type, else lo3_error.
+ * assign a1 = a2; if everything is correct!
+ *
+ * what is ok?:
+ * string as name, num as name
+ */
+void exec_asn(lo3_val a1, lo3_val a2) {
+
+	unsigned char buf[64], *name;
+	unsigned char numNameBuf[64];
+
+	if (!a1.chooseType) {
+		snprintf(buf, sizeof(buf), "%d", a1.value.num);
+		name = buf;
+
+	} else {
+		name = a1.value.string;
+	}
+
+	// var_get() would also work here, but it is just a wrapper around var_find()
+	if (var_find(name) == -1) {
+		lo3_error("Could not find <var> please check if it really exists!", "");
+		return;
+	}
+
+	// set
+	if (!a2.chooseType) {
+		var_setNum(name, a2.value.num);
+	} else {
+		var_setString(name, a2.value.string);
+	}
+}
+
+///// alu /////
+
+void exec_add(lo3_val a1, lo3_val a2) {
+
+	unsigned char buf[64];
+	unsigned char *name;
+
+	if (!a1.chooseType) {
+		snprintf(buf, sizeof(buf), "%d", a1.value.num);
+		name = buf;
+
+	} else {
+		name = a1.value.string;
+	}
+
+	if (var_find(name) == -1) {
+		lo3_error("Could not find this var, please check if you got something wrong", name);
+		return;
+	}
+
+	lo3_var *oldVar = var_get(name); // it must be right now, else var_find() was wrong before!
+
+	if (a2.chooseType) {
+		lo3_error("Arg1 requires TYPE String for +=", "");
+		return;
+	}
+
+	var_setNum(name, var_getNum(oldVar) + a2.value.num);
+}
+
+void exec_sub(lo3_val a1, lo3_val a2) {
+
+	unsigned char buf[64];
+	unsigned char *name;
+
+	if (!a1.chooseType) {
+		snprintf(buf, sizeof(buf), "%d", a1.value.num);
+		name = buf;
+
+	} else {
+		name = a1.value.string;
+	}
+
+	if (var_find(name) == -1) {
+		lo3_error("Could not find this var, please check if you got something wrong", name);
+		return;
+	}
+
+	lo3_var *oldVar = var_get(name); // it must be right now, else var_find() was wrong before!
+
+	if (a2.chooseType) {
+		lo3_error("Arg1 requires TYPE String for -=", "");
+		return;
+	}
+
+	var_setNum(name, var_getNum(oldVar) - a2.value.num);
+}
+
+void exec_mul(lo3_val a1, lo3_val a2) {
+
+	unsigned char buf[64];
+	unsigned char *name;
+
+	if (!a1.chooseType) {
+		snprintf(buf, sizeof(buf), "%d", a1.value.num);
+		name = buf;
+
+	} else {
+		name = a1.value.string;
+	}
+
+	if (var_find(name) == -1) {
+		lo3_error("Could not find this var, please check if you got something wrong", name);
+		return;
+	}
+
+	lo3_var *oldVar = var_get(name); // it must be right now, else var_find() was wrong before!
+
+	if (a2.chooseType) {
+		lo3_error("Arg1 requires TYPE String for *=", "");
+		return;
+	}
+
+	var_setNum(name, var_getNum(oldVar) * a2.value.num);
+}
+
+void exec_div(lo3_val a1, lo3_val a2) {
+
+	unsigned char buf[64];
+	unsigned char *name;
+
+	if (!a1.chooseType) {
+		snprintf(buf, sizeof(buf), "%d", a1.value.num);
+		name = buf;
+
+	} else {
+		name = a1.value.string;
+	}
+
+	if (var_find(name) == -1) {
+		lo3_error("Could not find this var, please check if you got something wrong", name);
+		return;
+	}
+
+	lo3_var *oldVar = var_get(name); // it must be right now, else var_find() was wrong before!
+
+	if (a2.chooseType) {
+		lo3_error("Arg1 requires TYPE String for /=", "");
+		return;
+	}
+
+	if (a2.value.num == 0) {
+		lo3_error("Division by zero", name);
+		return;
+	}
+
+	var_setNum(name, var_getNum(oldVar) / a2.value.num);
+}
+
+// will cmp and jmp! #?
+void exec_jmp(lo3_val a1, lo3_val a2) {
+
+	char buf[64], buf2[64];
+	char *name, *name2;
+
+	// label
+	if (!a1.chooseType) {
+		(void)snprintf(buf, sizeof(buf), "%d", a1.value.num);
+		name = buf;
+	} else {
+		name = a1.value.string;
+	}
+
+	if (cf_findLabel(name) == -1) {
+		return;
+	}
+
+	// g[0] == name2
+	if (a2.chooseType != 0) {
+		lo3_error("Illegal type, here arg1 must be an integer value to compare against!",
+		          "");
+		return;
+	}
+
+	if (g_getNum(0) == a2.value.num) {
+		rush = TRUE;
+
+		(void)strncpy(rush_target, name, sizeof(rush_target) - 1);
+		cf_jumpToLabel(name);
+	}
+	return;
+}
+
+// #c
+void exec_call(lo3_val a1, lo3_val a2) {
+}
+
+// #C - not in use - UB
+void exec_callS(lo3_val a1, lo3_val a2) {
+}
+
+void exec_label(lo3_val a1, lo3_val a2) {
+
+	char buf[64];
+	char *name;
+
+	if (!a1.chooseType) {
+		(void)snprintf(buf, sizeof(buf), "%d", a1.value.num);
+		name = buf;
+	} else {
+		name = a1.value.string;
+	}
+
+	if (cf_findLabel(name) != -1) {
+
+		if (rush && !strcmp(rush_target, name)) {
+			rush = FALSE;
+			return;
+		}
+		return;
+	}
+
+	cf_addLabel(name, lastLineOffset);
+}
+
+void exec_out(lo3_val a1, lo3_val a2) {
+
+	unsigned char buf[64];
+	unsigned char *name;
+
+	if (!a1.chooseType) {
+		(void)snprintf(buf, sizeof(buf), "%d", a1.value.num);
+		name = buf;
+	} else {
+		name = a1.value.string;
+	}
+
+	printf("%63s\n", name);
+}
+
+void exec_in(lo3_val a1, lo3_val a2) {
+
+	unsigned char buf[64] = {0}; // privides buf not initing
+	unsigned char *res;
+
+	unsigned char numNameBuf[64];
+	unsigned char *name;
+
+	res = fgets(buf, sizeof(buf), stdin);
+
+	if (res == NULL) {
+		lo3_error("Something went wrong while reading the stdin stream.\n"
+		          "Please check if you done anything wrong...",
+		          buf);
+		return;
+	}
+
+	// parse the '\n' away
+	buf[strcspn(buf, "\n")] = '\0';
+
+	lo3_val temp = pars_resv(buf);
+
+	// correct the a1.~type
+	if (!a1.chooseType) {
+		snprintf(numNameBuf, sizeof(numNameBuf), "%d", a1.value.num);
+		name = numNameBuf;
+	} else {
+		name = a1.value.string;
+	}
+
+	if (!a2.chooseType) {
+		var_setNum(name, temp.value.num);
+	} else {
+		var_setString(name, temp.value.string);
+	}
+}
+
+// compare num == num, if true -> g[0] = 1, else g[0] = 0;!!!
+void exec_cmp(lo3_val a1, lo3_val a2) {
+
+	if (a1.chooseType || a2.chooseType) {
+		lo3_error("You can not compare char*'s,\n"
+	    "Please use the coresponding std-func!, from {string.c}", "");
+		return;
+	}
+
+	lo3_val true, false;
+	true.value.num = TRUE;
+	true.chooseType = 0;
+
+	false.value.num = FALSE;
+	false.chooseType = 0;
+
+	if (a1.value.num == a2.value.num) {
+		g_set(0, true);
+		return;
+	}
+	g_set(0, false);
+}
+
+// compare num < num, if true -> g[0] = 1, else g[0] = 0;!!!
+void exec_small(lo3_val a1, lo3_val a2) {
+
+	if (a1.chooseType || a2.chooseType) {
+		lo3_error("You can not compare char*'s,\n"
+	    "Please use the coresponding std-func!, from {string.c}", "");
+		return;
+	}
+
+	lo3_val true, false;
+	true.value.num = TRUE;
+	true.chooseType = 0;
+
+	false.value.num = FALSE;
+	false.chooseType = 0;
+
+	if (a1.value.num < a2.value.num) {
+		g_set(0, true);
+		return;
+	}
+	g_set(0, false);
+}
+
+// compare num > num, if true -> g[0] = 1, else g[0] = 0;!!!
+void exec_big(lo3_val a1, lo3_val a2) {
+
+	if (a1.chooseType || a2.chooseType) {
+		lo3_error("You can not compare char*'s,\n"
+	    "Please use the coresponding std-func!, from {string.c}", "");
+		return;
+	}
+
+	lo3_val true, false;
+	true.value.num = TRUE;
+	true.chooseType = 0;
+
+	false.value.num = FALSE;
+	false.chooseType = 0;
+
+	if (a1.value.num > a2.value.num) {
+		g_set(0, true);
+		return;
+	}
+	g_set(0, false);
+}
+
+// #s <num> <arg> — platform syscall; result stored in g[0]
+void exec_syscall(lo3_val a1, lo3_val a2) {
+
+	if (a1.chooseType || a2.chooseType) {
+		lo3_error("syscall args must be numeric", "");
+		return;
+	}
+
+#ifdef __linux__
+	long ret = syscall((long)a1.value.num, (long)a2.value.num);
+
+	lo3_val result;
+	result.chooseType = 0;
+	result.value.num = (int)ret;
+	g_set(0, result);
+
+#else
+	lo3_warn("syscall is not supported on this platform", "");
+#endif
+}

--- a/future/v0.3.0/src/internal/specific-language.h
+++ b/future/v0.3.0/src/internal/specific-language.h
@@ -1,0 +1,66 @@
+// Copyright (c) 2026 seesee010
+// Read the License file for more informations about the license.
+
+#pragma once
+
+#include "bare-define.h"
+#include <string.h>
+
+typedef enum {
+
+	// assign
+	BSC_asn = '=',
+
+	// alu
+	ALU_add = '+',
+	ALU_sub = '-',
+	ALU_div = '/',
+	ALU_mul = '*',
+
+	// control
+	CNT_jmp = 'd',   // define a jmp point
+	CNT_call = 'c',  // call extern lib (uses fixed path)
+	CNT_callS = 'C', // call extern lib (better func!, uses relative path)
+	CNT_label = 'l', // define new label
+	CNT_new = 'n',   // define new variable
+	CNT_cmp = '?',
+	CNT_small = '<',
+	CNT_big = '>',
+
+	// stream
+	STM_out = 'o', // shifts sth into stdout
+	STM_in = 'i',  // shifts sth into stdin
+
+	CNT_free = 'f', // free a var
+
+	RET_good = '0', // stop the program with exit code 0
+	RET_bad = '1',  // return the program with exit code 1
+	RET_smart = 'r', // some feature which needs call func, but this is not avaible yet...
+
+	// syscall
+	SYS_call = 's' // platform syscall: #s <num> <arg>
+
+} lo3_cmds;
+
+////////// parser //////////
+lo3_val pars_resv(char type[64]);
+int pars_dispatch(lo3_cmds cmd, lo3_val a1, lo3_val a2);
+
+// execute func
+void exec_new(lo3_val a1, lo3_val a2);
+void exec_asn(lo3_val a1, lo3_val a2);
+void exec_add(lo3_val a1, lo3_val a2);
+void exec_sub(lo3_val a1, lo3_val a2);
+void exec_mul(lo3_val a1, lo3_val a2);
+void exec_div(lo3_val a1, lo3_val a2);
+void exec_jmp(lo3_val a1, lo3_val a2);
+void exec_call(lo3_val a1, lo3_val a2);
+void exec_callS(lo3_val a1, lo3_val a2);
+void exec_label(lo3_val a1, lo3_val a2);
+void exec_out(lo3_val a1, lo3_val a2);
+void exec_in(lo3_val a1, lo3_val a2);
+void exec_free(lo3_val a1, lo3_val a2);
+void exec_cmp(lo3_val a1, lo3_val a2);
+void exec_small(lo3_val a1, lo3_val a2);
+void exec_big(lo3_val a1, lo3_val a2);
+void exec_syscall(lo3_val a1, lo3_val a2);

--- a/future/v0.3.0/src/parsing.c
+++ b/future/v0.3.0/src/parsing.c
@@ -1,0 +1,334 @@
+// Copyright (c) 2026 seesee010
+// Read the License file for more informations about the license.
+//
+// You can find todos by reading the "todo" blocks.
+// But please read the whole block not only the single todo line
+
+#include "./internal/bare-define.h"
+#include "./internal/bare-var.h"
+#include "./internal/control-flow.h"
+#include "./internal/core.h"
+#include "./internal/global.h"
+#include "./internal/specific-language.h"
+#include <errno.h>
+#include <limits.h>
+
+volatile char LO3_STARTING_LINE = '#';
+
+int currentLine = 0;
+int lastLineOffset = 0;
+
+int pars_isFileValid(char *name, FILE **file) {
+
+	*file = fopen(name, "r");
+
+	if (*file == NULL) {
+		return -1;
+	}
+
+	size_t len = strlen(name);
+
+	if (len < 4 || strcmp(&name[len - 4], ".lo3") != 0) {
+		lo3_error("File must end with .lo3\n", name);
+		(void)(fclose((*file)));
+		return -1;
+	}
+	return 0;
+}
+
+int pars_file(FILE *file) {
+
+	char *line = NULL;
+	size_t len = 0;
+	char arg1[64] = {0}, arg2[64] = {0};
+
+	int pos0 = ftell(file);
+
+	// todo: make getline avaible on other os
+	//
+	// ///// MORE INFORMATIONS /////
+	// getline is not a c standardized lib and therefore should be defined somewhere else.
+	// Ways to solve that problem:
+	// - Create a getline MACRO and use that here
+	// - use the preprocessor funcs, like ifdef check for linux and win etc
+
+parsing:
+	while (lastLineOffset = ftell(file), GETLINE(&line, &len, file)) {
+
+		currentLine++;
+		line[strcspn(line, "\n")] = '\0';
+
+		// syntax sugar
+		if (line[0] == '@') {
+
+			if (line[1] == '.') {
+				LO3_STARTING_LINE = line[2];
+
+			} else if (line[1] == '{') {
+				// @{1:$10,10:_Hello}
+				// index | type | word
+
+				g_fasterInit(line);
+			}
+		}
+
+		if (line[0] != LO3_STARTING_LINE) {
+			continue;
+		}
+
+		if (strlen(line) < 3) {
+			lo3_warn("You used some kind of magic line,"
+			         "which is propaply not lo3-core syntax, are you sure you wanna do "
+			         "this???",
+			         "");
+			continue;
+		}
+
+		lo3_cmds cmds = (lo3_cmds)line[1];
+
+		// find the TYPES of arg
+
+		// could lead to wrong var names, but else it could eventually crash.
+		// Both are not that great.
+		// maybe there could be a check or lo3_warn() about wrong var name size.
+
+		(void)sscanf(&line[3], " %63s %63s", arg1, arg2);
+
+		lo3_val a1 = pars_resv(arg1);
+		lo3_val a2 = pars_resv(arg2);
+
+		signed int returnVal = pars_dispatch(cmds, a1, a2);
+
+		if (returnVal != -1) {
+			free(line);
+			return returnVal;
+		}
+
+		free(line);
+		line = NULL;
+		len = 0;
+	}
+
+	if (rush) {
+		fseek(file, pos0, SEEK_SET);
+
+		if (!isWarped) {
+			isWarped = TRUE;
+			goto parsing;
+
+		} else {
+			lo3_error("Could not find the label, did you misspell it???", "");
+			return -1;
+		}
+	}
+	return 0;
+}
+
+lo3_val pars_resv(char type[64]) {
+	lo3_val result;
+	result.type = type[0];
+	char *end;
+
+	int value;
+	lo3_var *var;
+
+	switch (result.type) {
+
+	// find the corresponding type
+	case TYPE_num:
+		errno = 0;
+
+		long val = strtol(&type[1], &end, 10);
+		if (errno != 0 || end == &type[1] || val > INT_MAX || val < INT_MIN) {
+			lo3_error("<num> is typeof integer!\nBut this value is not!", type);
+			result.value.num = 0;
+			result.chooseType = 0;
+			break;
+		}
+		result.value.num = (int)val;
+		result.chooseType = 0;
+		break;
+
+	case TYPE_array:
+
+		// logic:
+		// *X, lookup X, resolve the value as long as it is a number,
+		// 0 - 9 counts as values
+		//
+		// not allowed: "*A"
+
+		// *100 -> _Hello
+		errno = 0;
+
+		long idx = strtol(&type[1], &end, 10);
+		if (errno != 0 || end == &type[1] || idx < 0 || idx > INT_MAX) {
+			lo3_error("Invalid g[] index", type);
+			break;
+		}
+		lo3_val value = g_get((int)idx);
+
+		result.type = value.chooseType ? TYPE_string : TYPE_num;
+		result.value = value.value;
+		result.chooseType = value.chooseType ? 3 : 0;
+		break;
+
+	case TYPE_string:
+
+		result.value.string = &type[1];
+		result.chooseType = 3;
+		break;
+
+	case TYPE_var:
+
+		// resolve var
+		var = var_get(&type[1]);
+
+		if (var == NULL) {
+			lo3_error("Could not resolve var, because it was invalid! Or empty.", "");
+			break;
+		}
+
+		result.type = var_getType(var) ? TYPE_string : TYPE_num;
+		result.value = var_getValue(var);
+
+		result.chooseType = var_getType(var) ? 3 : 0;
+
+		// type: 0=num, 3=string (from ATYPE_ ... bitmasks, 1 and 2 are getting
+		// resolved, so it would be useless if you can write them)
+
+		// todo:
+		// If double exists: var need to resolve this!
+		break;
+
+	case TYPE_double:
+
+		// todo:
+		// Add doubles in lo3
+		//
+		// ///// More Information: /////
+		// Every exec_ will need other/more/etc code.
+		break;
+	default:
+
+		lo3_error("Could not fild the corresponding type! …\n Please enter "
+		          "something valid,"
+		          "You may want to visit "
+		          "https://github.com/lo3-lang/learn-the-syntax !!!",
+		          type);
+		break;
+	}
+	return result;
+}
+
+int pars_dispatch(lo3_cmds cmd, lo3_val a1, lo3_val a2) {
+
+	if (rush) {
+
+		switch (cmd) {
+		case CNT_label:
+			exec_label(a1, a2);
+			break;
+
+		default:
+			break;
+		}
+
+		return -1;
+	}
+
+	switch (cmd) {
+
+	case BSC_asn:
+
+		exec_asn(a1, a2);
+		break;
+
+	case ALU_add:
+
+		exec_add(a1, a2);
+		break;
+
+	case ALU_sub:
+
+		exec_sub(a1, a2);
+		break;
+
+	case ALU_mul:
+
+		exec_mul(a1, a2);
+		break;
+
+	case ALU_div:
+
+		exec_div(a1, a2);
+		break;
+
+	case CNT_jmp:
+
+		exec_jmp(a1, a2);
+		break;
+
+	case CNT_call:
+
+		exec_call(a1, a2);
+		break;
+
+	case CNT_callS:
+
+		exec_callS(a1, a2);
+		break;
+
+	case CNT_label:
+
+		exec_label(a1, a2);
+		break;
+
+	case CNT_new:
+		exec_new(a1, a2);
+		break;
+
+	case CNT_free:
+		exec_free(a1, a2);
+		break;
+
+	case STM_out:
+
+		exec_out(a1, a2);
+		break;
+
+	case STM_in:
+
+		exec_in(a1, a2);
+		break;
+
+	case RET_good:
+		return 0;
+
+	case RET_bad:
+		return 1;
+
+	case CNT_cmp:
+
+		exec_cmp(a1, a2);
+		break;
+
+	case CNT_small:
+		exec_small(a1, a2);
+		break;
+
+	case CNT_big:
+		exec_big(a1, a2);
+		break;
+
+	case SYS_call:
+
+		exec_syscall(a1, a2);
+		break;
+
+	default:
+		lo3_error("Unknown command!", "");
+		break;
+	}
+
+	return -1;
+}


### PR DESCRIPTION
Adds the `#s` syscall command to `future/v0.3.0/`.

## Changes

- New `SYS_call = 's'` entry in `lo3_cmds` enum
- `exec_syscall(a1, a2)` implementation: calls `syscall(num, arg)` on Linux, warns on other platforms, stores return value in `g[0]`
- Dispatch case added to `pars_dispatch()`

Closes #106

Generated with [Claude Code](https://claude.ai/code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Introduced LO3 script execution engine supporting variable management, assignment, and memory operations.
  * Added arithmetic operations including addition, subtraction, multiplication, and division with error handling.
  * Implemented control flow features: conditional jumps, function calls, and label management.
  * Added input/output operations for reading from and writing to console.
  * Implemented comparison operators for conditional logic.
  * Added platform system call integration support.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->