### PR TITLE
fix: remove forced 63-column padding in exec_out

### DIFF
--- a/src/execute.c
+++ b/src/execute.c
@@ -305,7 +305,7 @@ void exec_out(lo3_val a1, lo3_val a2) {
 		name = a1.value.string;
 	}
 
-	printf("%63s\n", name);
+	printf("%s\n", name);
 }
 
 void exec_in(lo3_val a1, lo3_val a2) {


### PR DESCRIPTION
Replace %63s with %s in exec_out so stdout output is no longer right-justified with leading spaces.

Fixes #116

Generated with [Claude Code](https://claude.ai/code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Removed output length restriction, allowing full variable names to display without truncation.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->