### PR TITLE
FIX(parsing.c): free() crash when freeing string literals

### DIFF
--- a/src/parsing.c
+++ b/src/parsing.c
@@ -226,7 +226,7 @@ lo3_val pars_resv(char type[64]) {
 		break;
 
 	case TYPE_string:
-		result.value.string = &type[1];
+		result.value.string = strdup(&type[1]);
 		result.chooseType = 3;
 		break;
 


### PR DESCRIPTION
String values in pars_resv() stored a pointer to the stack-allocated arg buffer instead of a heap copy, causing an invalid free() in var_freeAll(). Fixed by using strdup() to allocate on the heap.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Improved internal string handling to ensure more robust memory management.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->