### PR TITLE
FIX: make the test suite reliable and cross-platform (#213)

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,1 +1,2 @@
-*.lo3 linguist-language=lo3
+*.expected text eol=lf
+*.lo3 text eol=lf linguist-language=lo3

--- a/.github/workflows/compile-check.yml
+++ b/.github/workflows/compile-check.yml
@@ -1,101 +1,38 @@
 name: Compile Check
 
 on:
+  push:
+    branches: [main, "future/**"]
   pull_request:
     types: [opened, synchronize, reopened, ready_for_review]
 
 jobs:
-  compile:
+  build-and-test:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4
 
       - name: Build
-        id: build
         run: |
           cmake -B build
           cmake --build build
 
-      - name: Upload binary
-        if: steps.build.outcome == 'success'
-        uses: actions/upload-artifact@v4
-        with:
-          name: lo3-binary
-          path: bin/lo3
+      - name: C unit tests (ctest)
+        run: ctest --test-dir build --output-on-failure
 
-      - name: Report compilation status
+      - name: Rust unit tests
+        working-directory: test/unit/rust
+        run: cargo test -- --test-threads=1
+
+      - name: Syntax tests
+        run: python3 test/syntax/run_syntax_tests.py
+
+      - name: Report status
         if: always()
         run: |
-          if [ "${{ steps.build.outcome }}" = "success" ]; then
-            echo "## ✅ Compilation succeeded" >> $GITHUB_STEP_SUMMARY
-            echo "The source code compiled successfully." >> $GITHUB_STEP_SUMMARY
+          if [ "${{ job.status }}" = "success" ]; then
+            echo "## ✅ Build and all test suites passed" >> $GITHUB_STEP_SUMMARY
           else
-            echo "## ❌ Compilation failed" >> $GITHUB_STEP_SUMMARY
-            echo "The source code **failed to compile**. Tests will not run." >> $GITHUB_STEP_SUMMARY
-          fi
-
-  test:
-    needs: compile
-    runs-on: ubuntu-latest
-    steps:
-      - uses: actions/checkout@v4
-
-      - name: Download binary
-        uses: actions/download-artifact@v4
-        with:
-          name: lo3-binary
-          path: bin/
-
-      - name: Make executable
-        run: chmod +x bin/lo3
-
-      - name: Generate aggregate file
-        run: |
-          set -euo pipefail
-
-          SYNTAX_DIR="test/syntax"
-          AGGREGATE="test/general.lo3"
-          AGG_DIR="$(dirname "$AGGREGATE")"
-
-          if [ ! -d "$SYNTAX_DIR" ]; then
-            echo "::error::Syntax test dir '$SYNTAX_DIR' not found"
-            exit 1
-          fi
-
-          shopt -s nullglob
-          files=("$SYNTAX_DIR"/*.lo3)
-
-          if [ ${#files[@]} -eq 0 ]; then
-            echo "::error::No .lo3 test files in '$SYNTAX_DIR'"
-            exit 1
-          fi
-
-          mkdir -p "$AGG_DIR"
-          {
-            echo "@.%"
-            for f in "${files[@]}"; do
-              rel="$(realpath --relative-to="$AGG_DIR" "$f")"
-              echo "#include \"$rel\""
-            done
-          } > "$AGGREGATE"
-
-          echo "::group::Generated aggregate ($AGGREGATE)"
-          cat "$AGGREGATE"
-          echo "::endgroup::"
-
-      - name: Preprocess (C preprocessor)
-        run: cpp -P -x assembler-with-cpp test/general.lo3 -o test/general.preprocessed.lo3
-
-      - name: Run tests
-        id: tests
-        run: ./bin/lo3 test/general.preprocessed.lo3
-
-      - name: Report test status
-        if: always()
-        run: |
-          if [ "${{ steps.tests.outcome }}" = "success" ]; then
-            echo "## ✅ Tests passed" >> $GITHUB_STEP_SUMMARY
-          else
-            echo "## ❌ Tests failed" >> $GITHUB_STEP_SUMMARY
-            echo "The test run **failed**. Check the logs above." >> $GITHUB_STEP_SUMMARY
+            echo "## ❌ Build or tests failed" >> $GITHUB_STEP_SUMMARY
+            echo "Check the logs above for the failing step." >> $GITHUB_STEP_SUMMARY
           fi

--- a/.gitignore
+++ b/.gitignore
@@ -1,5 +1,7 @@
 build/*
 .cache/
+test/unit/rust/target/
+__pycache__/
 review.md
 build_plain/
 build_test/

--- a/src/parsing.c
+++ b/src/parsing.c
@@ -32,6 +32,7 @@ int pars_isFileValid(char *name, FILE **file) {
 	if (len < 4 || strcmp(&name[len - 4], ".lo3") != 0) {
 		lo3_error("File must end with .lo3\n", name);
 		(void)(fclose((*file)));
+		*file = NULL; // callers may fclose again — don't hand back a dangling FILE*
 		return -1;
 	}
 	return 0;

--- a/test/run_tests.py
+++ b/test/run_tests.py
@@ -3,6 +3,7 @@
 # Master test runner: Rust unit tests + C unit test (test_parsing) + syntax tests.
 
 import os
+import shutil
 import subprocess
 import sys
 
@@ -24,49 +25,59 @@ def run(cmd, **kwargs):
 
 def run_rust_unit_tests():
     section("UNIT TESTS — Rust (var / global / control-flow / execute / warnings)")
+
+    if shutil.which("cargo") is None:
+        print("  cargo not found — SKIPPING Rust unit tests")
+        return "SKIP (cargo not found)"
+
     r = run(["cargo", "test"], cwd=RUST_DIR)
-    return r.returncode == 0
+    return "PASS" if r.returncode == 0 else "FAIL"
 
 
 def run_c_unit_tests():
     section("UNIT TESTS — C/Unity (test_parsing)")
 
+    missing = [tool for tool in ("cmake", "ctest") if shutil.which(tool) is None]
+    if missing:
+        print(f"  {'/'.join(missing)} not found — SKIPPING C unit tests")
+        return f"SKIP ({'/'.join(missing)} not found)"
+
     r = run(["cmake", "-B", BUILD_DIR, "-S", REPO_ROOT, "-DCMAKE_BUILD_TYPE=Debug"])
     if r.returncode != 0:
         print("ERROR: cmake configure failed")
-        return False
+        return "FAIL"
 
     r = run(["cmake", "--build", BUILD_DIR, "--parallel"])
     if r.returncode != 0:
         print("ERROR: cmake build failed")
-        return False
+        return "FAIL"
 
     r = run(["ctest", "--output-on-failure", "--test-dir", BUILD_DIR])
-    return r.returncode == 0
+    return "PASS" if r.returncode == 0 else "FAIL"
 
 
 def run_syntax_tests():
     section("SYNTAX TESTS")
     r = subprocess.run([sys.executable, SYNTAX_RUNNER])
-    return r.returncode == 0
+    return "PASS" if r.returncode == 0 else "FAIL"
 
 
 def main():
-    rust_ok   = run_rust_unit_tests()
-    c_ok      = run_c_unit_tests()
-    syntax_ok = run_syntax_tests()
+    syntax_status = run_syntax_tests()
+    c_status      = run_c_unit_tests()
+    rust_status   = run_rust_unit_tests()
 
     section("SUMMARY")
-    print(f"  Unit tests (Rust):   {'PASS' if rust_ok   else 'FAIL'}")
-    print(f"  Unit tests (C):      {'PASS' if c_ok      else 'FAIL'}")
-    print(f"  Syntax tests:        {'PASS' if syntax_ok else 'FAIL'}")
+    print(f"  Syntax tests:        {syntax_status}")
+    print(f"  Unit tests (C):      {c_status}")
+    print(f"  Unit tests (Rust):   {rust_status}")
     print()
 
-    if rust_ok and c_ok and syntax_ok:
-        print("All tests passed.")
-        return 0
-    print("Some tests FAILED.")
-    return 1
+    if "FAIL" in (syntax_status, c_status, rust_status):
+        print("Some tests FAILED.")
+        return 1
+    print("All tests passed (skipped stages excluded).")
+    return 0
 
 
 if __name__ == "__main__":

--- a/test/syntax/run_syntax_tests.py
+++ b/test/syntax/run_syntax_tests.py
@@ -9,6 +9,8 @@ import sys
 SCRIPT_DIR = os.path.dirname(os.path.abspath(__file__))
 REPO_ROOT = os.path.dirname(os.path.dirname(SCRIPT_DIR))
 BIN = os.path.join(REPO_ROOT, "bin", "lo3")
+if os.name == "nt":
+    BIN += ".exe"
 
 def run_syntax_tests():
     if not os.path.isfile(BIN):
@@ -34,19 +36,25 @@ def run_syntax_tests():
             print(f"[SKIP] {base}  (no .expected file)")
             continue
 
-        with open(exp_path) as f:
-            expected = f.read()
+        with open(exp_path, encoding="utf-8", newline="") as f:
+            expected = f.read().replace("\r\n", "\n")
+
+        exp_rc = 0
+        rc_path = os.path.join(SCRIPT_DIR, base + ".exitcode")
+        if os.path.isfile(rc_path):
+            with open(rc_path) as f:
+                exp_rc = int(f.read().strip())
 
         result = subprocess.run([BIN, lo3_path], capture_output=True, timeout=10)
-        actual = result.stdout.decode("utf-8")
+        actual = result.stdout.decode("utf-8").replace("\r\n", "\n")
 
-        if actual == expected and result.returncode == 0:
+        if actual == expected and result.returncode == exp_rc:
             print(f"[PASS] {base}")
             passed += 1
         else:
             print(f"[FAIL] {base}")
-            if result.returncode != 0:
-                print(f"       exit code: {result.returncode}")
+            if result.returncode != exp_rc:
+                print(f"       exit code: expected {exp_rc}, got {result.returncode}")
             if actual != expected:
                 exp_lines = expected.splitlines()
                 act_lines = actual.splitlines()

--- a/test/unit/rust/.cargo/config.toml
+++ b/test/unit/rust/.cargo/config.toml
@@ -1,3 +1,0 @@
-[env]
-# C globals are not thread-safe; force single-threaded test execution.
-RUST_TEST_THREADS = "1"

--- a/test/unit/rust/Cargo.lock
+++ b/test/unit/rust/Cargo.lock
@@ -3,6 +3,12 @@
 version = 4
 
 [[package]]
+name = "bitflags"
+version = "2.13.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b4388bee8683e3d04af747c73422af53102d2bd24d9eadb6cbc100baef4b43f8"
+
+[[package]]
 name = "cc"
 version = "1.2.60"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -13,10 +19,51 @@ dependencies = [
 ]
 
 [[package]]
+name = "cfg-if"
+version = "1.0.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9330f8b2ff13f34540b44e946ef35111825727b38d33286ef986142615121801"
+
+[[package]]
 name = "find-msvc-tools"
 version = "0.1.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5baebc0774151f905a1a2cc41989300b1e6fbb29aff0ceffa1064fdd3088d582"
+
+[[package]]
+name = "futures-core"
+version = "0.3.32"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7e3450815272ef58cec6d564423f6e755e25379b217b0bc688e295ba24df6b1d"
+
+[[package]]
+name = "futures-executor"
+version = "0.3.32"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "baf29c38818342a3b26b5b923639e7b1f4a61fc5e76102d4b1981c6dc7a7579d"
+dependencies = [
+ "futures-core",
+ "futures-task",
+ "futures-util",
+]
+
+[[package]]
+name = "futures-task"
+version = "0.3.32"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "037711b3d59c33004d3856fbdc83b99d4ff37a24768fa1be9ce3538a1cde4393"
+
+[[package]]
+name = "futures-util"
+version = "0.3.32"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "389ca41296e6190b48053de0321d02a77f32f8a5d2461dd38762c0593805c6d6"
+dependencies = [
+ "futures-core",
+ "futures-task",
+ "pin-project-lite",
+ "slab",
+]
 
 [[package]]
 name = "libc"
@@ -30,6 +77,115 @@ version = "0.1.0"
 dependencies = [
  "cc",
  "libc",
+ "serial_test",
+]
+
+[[package]]
+name = "lock_api"
+version = "0.4.14"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "224399e74b87b5f3557511d98dff8b14089b3dadafcab6bb93eab67d3aace965"
+dependencies = [
+ "scopeguard",
+]
+
+[[package]]
+name = "log"
+version = "0.4.33"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0ceec5bc11778974d1bcb055b18002eba7f4b3518b6a0081b3af5f21666da9ad"
+
+[[package]]
+name = "once_cell"
+version = "1.21.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9f7c3e4beb33f85d45ae3e3a1792185706c8e16d043238c593331cc7cd313b50"
+
+[[package]]
+name = "parking_lot"
+version = "0.12.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "93857453250e3077bd71ff98b6a65ea6621a19bb0f559a85248955ac12c45a1a"
+dependencies = [
+ "lock_api",
+ "parking_lot_core",
+]
+
+[[package]]
+name = "parking_lot_core"
+version = "0.9.12"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2621685985a2ebf1c516881c026032ac7deafcda1a2c9b7850dc81e3dfcb64c1"
+dependencies = [
+ "cfg-if",
+ "libc",
+ "redox_syscall",
+ "smallvec",
+ "windows-link",
+]
+
+[[package]]
+name = "pin-project-lite"
+version = "0.2.17"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a89322df9ebe1c1578d689c92318e070967d1042b512afbe49518723f4e6d5cd"
+
+[[package]]
+name = "proc-macro2"
+version = "1.0.106"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8fd00f0bb2e90d81d1044c2b32617f68fcb9fa3bb7640c23e9c748e53fb30934"
+dependencies = [
+ "unicode-ident",
+]
+
+[[package]]
+name = "quote"
+version = "1.0.46"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "dfbc457d0c7a0759a614551b11a6409e5951f6c7537be1f1b7682b9ae9230368"
+dependencies = [
+ "proc-macro2",
+]
+
+[[package]]
+name = "redox_syscall"
+version = "0.5.18"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ed2bf2547551a7053d6fdfafda3f938979645c44812fbfcda098faae3f1a362d"
+dependencies = [
+ "bitflags",
+]
+
+[[package]]
+name = "scopeguard"
+version = "1.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "94143f37725109f92c262ed2cf5e59bce7498c01bcc1502d7b9afe439a4e9f49"
+
+[[package]]
+name = "serial_test"
+version = "3.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "699f4197115b8a7e7ff19c9a315a4bd6fffec26cc4626ef45ecaea389e081c6d"
+dependencies = [
+ "futures-executor",
+ "futures-util",
+ "log",
+ "once_cell",
+ "parking_lot",
+ "serial_test_derive",
+]
+
+[[package]]
+name = "serial_test_derive"
+version = "3.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "94e153fc76e1c6a068703d6d29c508a0b15c061c4b7e43da59cc097bc342673c"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn",
 ]
 
 [[package]]
@@ -37,3 +193,38 @@ name = "shlex"
 version = "1.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0fda2ff0d084019ba4d7c6f371c95d8fd75ce3524c3cb8fb653a3023f6323e64"
+
+[[package]]
+name = "slab"
+version = "0.4.12"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0c790de23124f9ab44544d7ac05d60440adc586479ce501c1d6d7da3cd8c9cf5"
+
+[[package]]
+name = "smallvec"
+version = "1.15.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8ed6a63f02c8539c91a8685a86f4099661ba3da017932f6ebbea6de3f0fa7c90"
+
+[[package]]
+name = "syn"
+version = "2.0.118"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1b9ae57f904213ebb649ce6895b8a66c66f0203b9319718f69a5612a065b1422"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "unicode-ident",
+]
+
+[[package]]
+name = "unicode-ident"
+version = "1.0.24"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e6e4313cd5fcd3dad5cafa179702e2b244f760991f45397d14d4ebf38247da75"
+
+[[package]]
+name = "windows-link"
+version = "0.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f0805222e57f7521d6a62e36fa9163bc891acd422f971defe97d64e70d0a4fe5"

--- a/test/unit/rust/Cargo.toml
+++ b/test/unit/rust/Cargo.toml
@@ -9,5 +9,10 @@ name = "lo3_tests"
 [dependencies]
 libc = "0.2"
 
+[dev-dependencies]
+# Tests poke process-wide C globals (var list, g[], cf, ...) — they must not
+# run concurrently. Every test is marked #[serial] (issue #180).
+serial_test = "3"
+
 [build-dependencies]
 cc = "1"

--- a/test/unit/rust/build.rs
+++ b/test/unit/rust/build.rs
@@ -7,6 +7,7 @@ fn main() {
         .file(format!("{src}/execute.c"))
         .file(format!("{src}/warnings.c"))
         .file(format!("{src}/parsing.c"))
+        .file(format!("{src}/lo3-getLine.c")) // Windows getline shim (#ifdef _WIN32 inside)
         .file("stubs.c")
         .include(format!("{src}/internal"))
         .define("_POSIX_C_SOURCE", "200809L")

--- a/test/unit/rust/src/control_flow_tests.rs
+++ b/test/unit/rust/src/control_flow_tests.rs
@@ -1,21 +1,22 @@
 use super::*;
+use serial_test::serial;
 use std::ffi::CString;
 
 fn setup() { unsafe { reset_cf(); } }
+fn teardown() { unsafe { reset_cf(); } }
 fn cstr(s: &str) -> CString { CString::new(s).unwrap() }
 
 macro_rules! with_cf {
-    ($body:block) => {{ setup(); $body; }};
+    ($body:block) => {{ setup(); $body; teardown(); }};
 }
 
-// IMPORTANT: cf_addLabel stores raw pointers into cf.names[].
-// Every CString whose pointer is passed to cf_addLabel MUST be bound to a
-// let binding that lives for the full duration of the test — temporaries are
-// dropped at the end of the statement, leaving a dangling pointer in cf.names.
+// cf_addLabel strdup()s the name into cf.names[], so the malloc'd copies must
+// be freed after each test — reset_cf() (setup and teardown) takes care of that.
 
 // ── cf_findLabel ──────────────────────────────────────────────────────────────
 
 #[test]
+#[serial]
 fn findlabel_empty_returns_minus1() {
     with_cf!({
         assert_eq!(-1, unsafe { cf_findLabel(cstr("any").as_ptr()) });
@@ -23,6 +24,7 @@ fn findlabel_empty_returns_minus1() {
 }
 
 #[test]
+#[serial]
 fn findlabel_after_add() {
     with_cf!({
         let alpha = cstr("alpha");
@@ -32,6 +34,7 @@ fn findlabel_after_add() {
 }
 
 #[test]
+#[serial]
 fn findlabel_unknown_returns_minus1() {
     with_cf!({
         let known = cstr("known");
@@ -41,6 +44,7 @@ fn findlabel_unknown_returns_minus1() {
 }
 
 #[test]
+#[serial]
 fn findlabel_multiple() {
     with_cf!({
         let l1 = cstr("l1");
@@ -61,6 +65,7 @@ fn findlabel_multiple() {
 // ── cf_addLabel ───────────────────────────────────────────────────────────────
 
 #[test]
+#[serial]
 fn addlabel_returns_zero_on_success() {
     with_cf!({
         let lbl = cstr("newlabel");
@@ -69,6 +74,7 @@ fn addlabel_returns_zero_on_success() {
 }
 
 #[test]
+#[serial]
 fn addlabel_duplicate_returns_minus1() {
     with_cf!({
         let dup = cstr("dup");
@@ -78,6 +84,7 @@ fn addlabel_duplicate_returns_minus1() {
 }
 
 #[test]
+#[serial]
 fn addlabel_increments_count() {
     with_cf!({
         let a = cstr("a");
@@ -91,6 +98,7 @@ fn addlabel_increments_count() {
 }
 
 #[test]
+#[serial]
 fn addlabel_full_returns_minus1() {
     with_cf!({
         let labels: Vec<CString> = (0..ARRAY_SIZE - 1)
@@ -107,6 +115,7 @@ fn addlabel_full_returns_minus1() {
 // ── cf_getPos ─────────────────────────────────────────────────────────────────
 
 #[test]
+#[serial]
 fn getpos_known_label() {
     with_cf!({
         let pos_test = cstr("pos_test");
@@ -116,6 +125,7 @@ fn getpos_known_label() {
 }
 
 #[test]
+#[serial]
 fn getpos_unknown_returns_minus1() {
     with_cf!({
         assert_eq!(-1, unsafe { cf_getPos(cstr("ghost").as_ptr()) });
@@ -123,6 +133,7 @@ fn getpos_unknown_returns_minus1() {
 }
 
 #[test]
+#[serial]
 fn getpos_multiple() {
     with_cf!({
         let x = cstr("x");
@@ -139,6 +150,7 @@ fn getpos_multiple() {
 // ── cf_getCursorPos ───────────────────────────────────────────────────────────
 
 #[test]
+#[serial]
 fn getcursorpos_always_minus1() {
     assert_eq!(-1, unsafe { cf_getCursorPos() });
 }
@@ -146,6 +158,7 @@ fn getcursorpos_always_minus1() {
 // ── cf_jumpToLabel ────────────────────────────────────────────────────────────
 
 #[test]
+#[serial]
 fn jumptolabel_nonexistent_returns_minus1() {
     with_cf!({
         assert_eq!(-1, unsafe { cf_jumpToLabel(cstr("noexist").as_ptr()) });
@@ -153,6 +166,7 @@ fn jumptolabel_nonexistent_returns_minus1() {
 }
 
 #[test]
+#[serial]
 fn jumptolabel_existing_returns_zero() {
     with_cf!({
         let jmp = cstr("jmp_target");
@@ -172,6 +186,7 @@ fn jumptolabel_existing_returns_zero() {
 // ── rush / isWarped flags ─────────────────────────────────────────────────────
 
 #[test]
+#[serial]
 fn rush_initially_false() {
     with_cf!({
         assert_eq!(FALSE, unsafe { rush });
@@ -179,6 +194,7 @@ fn rush_initially_false() {
 }
 
 #[test]
+#[serial]
 fn iswarped_initially_false() {
     with_cf!({
         assert_eq!(FALSE, unsafe { isWarped });

--- a/test/unit/rust/src/execute_tests.rs
+++ b/test/unit/rust/src/execute_tests.rs
@@ -1,4 +1,5 @@
 use super::*;
+use serial_test::serial;
 use std::ffi::{CStr, CString};
 
 static mut DUMMY: [i8; 2] = [0, 0];
@@ -9,7 +10,12 @@ fn setup() {
         reset_cf();
     }
 }
-fn teardown() { unsafe { var_freeAll(); } }
+fn teardown() {
+    unsafe {
+        var_freeAll();
+        reset_cf(); // frees labels strdup'd by exec_label
+    }
+}
 
 macro_rules! with_exec {
     ($body:block) => {{ setup(); $body; teardown(); }};
@@ -23,6 +29,7 @@ fn dummy() -> *mut i8 { unsafe { DUMMY.as_mut_ptr() } }
 // ── exec_new ─────────────────────────────────────────────────────────────────
 
 #[test]
+#[serial]
 fn new_creates_num_var() {
     with_exec!({
         unsafe { exec_new(sval("myvar"), nval(0), dummy()); }
@@ -31,6 +38,7 @@ fn new_creates_num_var() {
 }
 
 #[test]
+#[serial]
 fn new_creates_string_var() {
     with_exec!({
         unsafe { exec_new(sval("strvar"), nval(3), dummy()); }
@@ -39,6 +47,7 @@ fn new_creates_string_var() {
 }
 
 #[test]
+#[serial]
 fn new_duplicate_no_crash() {
     with_exec!({
         unsafe {
@@ -52,6 +61,7 @@ fn new_duplicate_no_crash() {
 // ── exec_free ────────────────────────────────────────────────────────────────
 
 #[test]
+#[serial]
 fn free_deletes_var() {
     with_exec!({
         unsafe {
@@ -63,6 +73,7 @@ fn free_deletes_var() {
 }
 
 #[test]
+#[serial]
 fn free_nonexistent_no_crash() {
     with_exec!({
         unsafe { exec_free(sval("ghost"), nval(0), dummy()); }
@@ -72,6 +83,7 @@ fn free_nonexistent_no_crash() {
 // ── exec_asn ─────────────────────────────────────────────────────────────────
 
 #[test]
+#[serial]
 fn asn_assigns_num() {
     with_exec!({
         unsafe {
@@ -84,6 +96,7 @@ fn asn_assigns_num() {
 }
 
 #[test]
+#[serial]
 fn asn_assigns_string() {
     with_exec!({
         unsafe {
@@ -98,6 +111,7 @@ fn asn_assigns_string() {
 }
 
 #[test]
+#[serial]
 fn asn_nonexistent_no_crash() {
     with_exec!({
         unsafe { exec_asn(sval("noexist"), nval(1), dummy()); }
@@ -107,6 +121,7 @@ fn asn_nonexistent_no_crash() {
 // ── exec_add ─────────────────────────────────────────────────────────────────
 
 #[test]
+#[serial]
 fn add_basic() {
     with_exec!({
         unsafe {
@@ -120,6 +135,7 @@ fn add_basic() {
 }
 
 #[test]
+#[serial]
 fn add_negative_operand() {
     with_exec!({
         unsafe {
@@ -133,6 +149,7 @@ fn add_negative_operand() {
 }
 
 #[test]
+#[serial]
 fn add_nonexistent_no_crash() {
     with_exec!({
         unsafe { exec_add(sval("noexist"), nval(1), dummy()); }
@@ -142,6 +159,7 @@ fn add_nonexistent_no_crash() {
 // ── exec_sub ─────────────────────────────────────────────────────────────────
 
 #[test]
+#[serial]
 fn sub_basic() {
     with_exec!({
         unsafe {
@@ -155,6 +173,7 @@ fn sub_basic() {
 }
 
 #[test]
+#[serial]
 fn sub_result_negative() {
     with_exec!({
         unsafe {
@@ -170,6 +189,7 @@ fn sub_result_negative() {
 // ── exec_mul ─────────────────────────────────────────────────────────────────
 
 #[test]
+#[serial]
 fn mul_basic() {
     with_exec!({
         unsafe {
@@ -183,6 +203,7 @@ fn mul_basic() {
 }
 
 #[test]
+#[serial]
 fn mul_by_zero() {
     with_exec!({
         unsafe {
@@ -198,6 +219,7 @@ fn mul_by_zero() {
 // ── exec_div ─────────────────────────────────────────────────────────────────
 
 #[test]
+#[serial]
 fn div_basic() {
     with_exec!({
         unsafe {
@@ -211,6 +233,7 @@ fn div_basic() {
 }
 
 #[test]
+#[serial]
 fn div_truncates() {
     with_exec!({
         unsafe {
@@ -224,6 +247,7 @@ fn div_truncates() {
 }
 
 #[test]
+#[serial]
 fn div_by_zero_no_crash_value_unchanged() {
     with_exec!({
         unsafe {
@@ -239,6 +263,7 @@ fn div_by_zero_no_crash_value_unchanged() {
 // ── exec_label ───────────────────────────────────────────────────────────────
 
 #[test]
+#[serial]
 fn label_registers_label() {
     with_exec!({
         unsafe { exec_label(sval("myLabel"), nval(0), dummy()); }
@@ -247,6 +272,7 @@ fn label_registers_label() {
 }
 
 #[test]
+#[serial]
 fn label_duplicate_no_crash() {
     with_exec!({
         unsafe {
@@ -260,6 +286,7 @@ fn label_duplicate_no_crash() {
 // ── exec_out ─────────────────────────────────────────────────────────────────
 
 #[test]
+#[serial]
 fn out_num_no_crash() {
     with_exec!({
         unsafe { exec_out(nval(42), nval(0), dummy()); }
@@ -267,6 +294,7 @@ fn out_num_no_crash() {
 }
 
 #[test]
+#[serial]
 fn out_string_no_crash() {
     with_exec!({
         unsafe { exec_out(sval("hello world"), nval(0), dummy()); }

--- a/test/unit/rust/src/global_tests.rs
+++ b/test/unit/rust/src/global_tests.rs
@@ -1,4 +1,5 @@
 use super::*;
+use serial_test::serial;
 
 // Global array `g` persists between tests; use distinct indices per test to avoid
 // cross-test contamination. Indices >= 50 are reserved for these tests.
@@ -8,22 +9,26 @@ fn num_val(n: i32) -> lo3_val { lo3_val::num(n) }
 // ── g_isSet ───────────────────────────────────────────────────────────────────
 
 #[test]
+#[serial]
 fn isset_initial_zero() {
     assert_eq!(0, unsafe { g_isSet(50) });
 }
 
 #[test]
+#[serial]
 fn isset_after_set_is_one() {
     unsafe { g_set(51, num_val(5)); }
     assert_eq!(1, unsafe { g_isSet(51) });
 }
 
 #[test]
+#[serial]
 fn isset_oob_high_returns_minus1() {
     assert_eq!(-1, unsafe { g_isSet(100) });
 }
 
 #[test]
+#[serial]
 fn isset_oob_low_returns_minus1() {
     assert_eq!(-1, unsafe { g_isSet(-1) });
 }
@@ -31,6 +36,7 @@ fn isset_oob_low_returns_minus1() {
 // ── g_set / g_get ─────────────────────────────────────────────────────────────
 
 #[test]
+#[serial]
 fn set_and_get_num() {
     unsafe {
         g_set(52, num_val(42));
@@ -40,6 +46,7 @@ fn set_and_get_num() {
 }
 
 #[test]
+#[serial]
 fn set_oob_no_crash() {
     unsafe { g_set(200, num_val(1)); }
 }
@@ -47,12 +54,14 @@ fn set_oob_no_crash() {
 // ── g_getNum ─────────────────────────────────────────────────────────────────
 
 #[test]
+#[serial]
 fn getnum_after_set() {
     unsafe { g_set(53, num_val(99)); }
     assert_eq!(99, unsafe { g_getNum(53) });
 }
 
 #[test]
+#[serial]
 fn getnum_oob_returns_minus1() {
     assert_eq!(-1, unsafe { g_getNum(100) });
 }
@@ -60,6 +69,7 @@ fn getnum_oob_returns_minus1() {
 // ── g_getType / g_setType ─────────────────────────────────────────────────────
 
 #[test]
+#[serial]
 fn gettype_after_set_is_num() {
     unsafe { g_set(54, num_val(1)); }
     // g_set always writes chooseType=0 (num) for new entries
@@ -67,6 +77,7 @@ fn gettype_after_set_is_num() {
 }
 
 #[test]
+#[serial]
 fn settype_string() {
     unsafe {
         g_set(55, num_val(0));
@@ -77,12 +88,14 @@ fn settype_string() {
 }
 
 #[test]
+#[serial]
 fn settype_oob_returns_minus1() {
     let type_val = lo3_val::num(0);
     assert_eq!(-1, unsafe { g_setType(200, type_val) });
 }
 
 #[test]
+#[serial]
 fn settype_invalid_type_returns_minus1() {
     unsafe { g_set(56, num_val(0)); }
     let bad_type = lo3_val { r#type: TYPE_NUM, chooseType: 99, value: lo3_value { num: 99 } };
@@ -92,6 +105,7 @@ fn settype_invalid_type_returns_minus1() {
 // ── g_getValue ────────────────────────────────────────────────────────────────
 
 #[test]
+#[serial]
 fn getvalue_returns_placeholder_choosetype_minus1() {
     let v = unsafe { g_getValue(57) };
     assert_eq!(-1, v.chooseType);
@@ -101,6 +115,7 @@ fn getvalue_returns_placeholder_choosetype_minus1() {
 // Indices 60-69 are reserved for these tests.
 
 #[test]
+#[serial]
 fn faster_init_single_num_sets_value() {
     // @{60:$42} — numeric entry must store 42 at index 60
     unsafe {
@@ -111,6 +126,7 @@ fn faster_init_single_num_sets_value() {
 }
 
 #[test]
+#[serial]
 fn faster_init_single_num_marks_isset() {
     // g_isSet must flip to 1 after g_fasterInit writes the entry
     unsafe {
@@ -121,6 +137,7 @@ fn faster_init_single_num_marks_isset() {
 }
 
 #[test]
+#[serial]
 fn faster_init_string_entry_sets_string_type() {
     // @{62:_Hello} — string entry must record chooseType=3
     unsafe {
@@ -131,6 +148,7 @@ fn faster_init_string_entry_sets_string_type() {
 }
 
 #[test]
+#[serial]
 fn faster_init_empty_braces_no_crash() {
     // @{} — nothing to initialise, must not crash or panic
     unsafe {
@@ -140,6 +158,7 @@ fn faster_init_empty_braces_no_crash() {
 }
 
 #[test]
+#[serial]
 fn faster_init_negative_num() {
     // @{63:$-5} — atoi must handle the minus sign correctly
     unsafe {
@@ -150,6 +169,7 @@ fn faster_init_negative_num() {
 }
 
 #[test]
+#[serial]
 fn faster_init_last_valid_index_no_crash() {
     // index 99 is the last in-bounds slot (G_SIZE = 100)
     unsafe {

--- a/test/unit/rust/src/lib.rs
+++ b/test/unit/rust/src/lib.rs
@@ -10,7 +10,7 @@ pub const TYPE_VAR: i32    = b'%' as i32;
 pub const FALSE: i8 = 0;
 pub const TRUE:  i8 = 1;
 
-pub const ARRAY_SIZE: usize = 254;
+pub const ARRAY_SIZE: usize = 256;
 pub const G_SIZE:     usize = 100;
 
 // ── lo3_value union ──────────────────────────────────────────────────────────
@@ -115,7 +115,14 @@ pub unsafe fn c_strdup(s: &str) -> *mut i8 {
 }
 
 /// Reset control-flow globals between tests.
+/// cf_addLabel strdup()s every label name into cf.names[], so free them
+/// before zeroing the struct — otherwise each test leaks its labels (#180).
 pub unsafe fn reset_cf() {
+    for i in 0..ARRAY_SIZE {
+        if !cf.names[i].is_null() {
+            libc::free(cf.names[i] as *mut libc::c_void);
+        }
+    }
     std::ptr::write_bytes(&raw mut cf, 0, 1);
     rush        = FALSE;
     isWarped    = FALSE;

--- a/test/unit/rust/src/var_tests.rs
+++ b/test/unit/rust/src/var_tests.rs
@@ -1,4 +1,5 @@
 use super::*;
+use serial_test::serial;
 use std::ffi::{CStr, CString};
 
 fn setup() { unsafe { var_init(); } }
@@ -13,6 +14,7 @@ fn cstr(s: &str) -> CString { CString::new(s).unwrap() }
 // ── var_find ─────────────────────────────────────────────────────────────────
 
 #[test]
+#[serial]
 fn find_returns_minus1_when_empty() {
     with_vars!({
         assert_eq!(-1, unsafe { var_find(cstr("x").as_ptr()) });
@@ -20,6 +22,7 @@ fn find_returns_minus1_when_empty() {
 }
 
 #[test]
+#[serial]
 fn find_returns_minus1_for_unknown() {
     with_vars!({
         unsafe { var_create(cstr("known").as_ptr(), 0); }
@@ -28,6 +31,7 @@ fn find_returns_minus1_for_unknown() {
 }
 
 #[test]
+#[serial]
 fn find_returns_valid_index_after_create() {
     with_vars!({
         unsafe { var_create(cstr("myvar").as_ptr(), 0); }
@@ -36,6 +40,7 @@ fn find_returns_valid_index_after_create() {
 }
 
 #[test]
+#[serial]
 fn find_multiple_vars() {
     with_vars!({
         unsafe {
@@ -53,6 +58,7 @@ fn find_multiple_vars() {
 // ── var_create ───────────────────────────────────────────────────────────────
 
 #[test]
+#[serial]
 fn create_num_type() {
     with_vars!({
         unsafe { var_create(cstr("numvar").as_ptr(), 0); }
@@ -61,6 +67,7 @@ fn create_num_type() {
 }
 
 #[test]
+#[serial]
 fn create_string_type() {
     with_vars!({
         unsafe { var_create(cstr("strvar").as_ptr(), 3); }
@@ -69,6 +76,7 @@ fn create_string_type() {
 }
 
 #[test]
+#[serial]
 fn create_empty_name_no_crash() {
     with_vars!({
         unsafe { var_create(cstr("").as_ptr(), 0); }
@@ -77,6 +85,7 @@ fn create_empty_name_no_crash() {
 }
 
 #[test]
+#[serial]
 fn create_null_name_no_crash() {
     with_vars!({
         unsafe { var_create(std::ptr::null(), 0); }
@@ -84,6 +93,7 @@ fn create_null_name_no_crash() {
 }
 
 #[test]
+#[serial]
 fn create_duplicate_no_crash() {
     with_vars!({
         unsafe {
@@ -97,6 +107,7 @@ fn create_duplicate_no_crash() {
 // ── var_get ──────────────────────────────────────────────────────────────────
 
 #[test]
+#[serial]
 fn get_returns_non_null_for_existing() {
     with_vars!({
         unsafe { var_create(cstr("g_test").as_ptr(), 0); }
@@ -105,6 +116,7 @@ fn get_returns_non_null_for_existing() {
 }
 
 #[test]
+#[serial]
 fn get_returns_null_for_missing() {
     with_vars!({
         assert!(unsafe { var_get(cstr("ghost").as_ptr()) }.is_null());
@@ -114,6 +126,7 @@ fn get_returns_null_for_missing() {
 // ── var_getType ──────────────────────────────────────────────────────────────
 
 #[test]
+#[serial]
 fn gettype_num() {
     with_vars!({
         unsafe { var_create(cstr("nvar").as_ptr(), 0); }
@@ -123,6 +136,7 @@ fn gettype_num() {
 }
 
 #[test]
+#[serial]
 fn gettype_string() {
     with_vars!({
         unsafe { var_create(cstr("svar").as_ptr(), 3); }
@@ -134,6 +148,7 @@ fn gettype_string() {
 // ── var_setNum / var_getNum ───────────────────────────────────────────────────
 
 #[test]
+#[serial]
 fn setnum_and_getnum() {
     with_vars!({
         unsafe {
@@ -146,6 +161,7 @@ fn setnum_and_getnum() {
 }
 
 #[test]
+#[serial]
 fn setnum_negative() {
     with_vars!({
         unsafe {
@@ -158,6 +174,7 @@ fn setnum_negative() {
 }
 
 #[test]
+#[serial]
 fn setnum_zero() {
     with_vars!({
         unsafe {
@@ -170,6 +187,7 @@ fn setnum_zero() {
 }
 
 #[test]
+#[serial]
 fn setnum_overwrite() {
     with_vars!({
         unsafe {
@@ -183,6 +201,7 @@ fn setnum_overwrite() {
 }
 
 #[test]
+#[serial]
 fn setnum_wrong_type_no_crash() {
     with_vars!({
         unsafe {
@@ -193,6 +212,7 @@ fn setnum_wrong_type_no_crash() {
 }
 
 #[test]
+#[serial]
 fn setnum_nonexistent_no_crash() {
     with_vars!({
         unsafe { var_setNum(cstr("noexist").as_ptr(), 1); }
@@ -202,6 +222,7 @@ fn setnum_nonexistent_no_crash() {
 // ── var_setString / var_getString ─────────────────────────────────────────────
 
 #[test]
+#[serial]
 fn setstring_and_getstring() {
     with_vars!({
         unsafe {
@@ -216,6 +237,7 @@ fn setstring_and_getstring() {
 }
 
 #[test]
+#[serial]
 fn setstring_wrong_type_no_crash() {
     with_vars!({
         unsafe {
@@ -226,6 +248,7 @@ fn setstring_wrong_type_no_crash() {
 }
 
 #[test]
+#[serial]
 fn setstring_nonexistent_no_crash() {
     with_vars!({
         unsafe { var_setString(cstr("noexist").as_ptr(), cstr("x").as_ptr() as *mut i8); }
@@ -235,6 +258,7 @@ fn setstring_nonexistent_no_crash() {
 // ── var_free ──────────────────────────────────────────────────────────────────
 
 #[test]
+#[serial]
 fn free_removes_var() {
     with_vars!({
         unsafe {
@@ -246,6 +270,7 @@ fn free_removes_var() {
 }
 
 #[test]
+#[serial]
 fn free_nonexistent_no_crash() {
     with_vars!({
         unsafe { var_free(cstr("ghost").as_ptr()); }
@@ -253,6 +278,7 @@ fn free_nonexistent_no_crash() {
 }
 
 #[test]
+#[serial]
 fn free_last_element() {
     with_vars!({
         unsafe {
@@ -264,6 +290,7 @@ fn free_last_element() {
 }
 
 #[test]
+#[serial]
 fn free_middle_element() {
     with_vars!({
         unsafe {
@@ -281,6 +308,7 @@ fn free_middle_element() {
 // ── var_getValue ──────────────────────────────────────────────────────────────
 
 #[test]
+#[serial]
 fn getvalue_num() {
     with_vars!({
         unsafe {

--- a/test/unit/rust/src/warnings_tests.rs
+++ b/test/unit/rust/src/warnings_tests.rs
@@ -1,4 +1,5 @@
 use super::*;
+use serial_test::serial;
 use std::ffi::CString;
 
 fn cstr(s: &str) -> CString { CString::new(s).unwrap() }
@@ -7,22 +8,26 @@ fn cstr(s: &str) -> CString { CString::new(s).unwrap() }
 // Output goes to stderr, which is fine in test runs.
 
 #[test]
+#[serial]
 fn warn_basic_no_crash() {
     unsafe { lo3_warn(cstr("test warning").as_ptr(), cstr("ctx").as_ptr()); }
 }
 
 #[test]
+#[serial]
 fn warn_null_context_no_crash() {
     unsafe { lo3_warn(cstr("no context").as_ptr(), std::ptr::null()); }
 }
 
 #[test]
+#[serial]
 fn warn_empty_message_no_crash() {
     // Empty msg triggers the internal lo3_error path — must not crash.
     unsafe { lo3_warn(cstr("").as_ptr(), cstr("ctx").as_ptr()); }
 }
 
 #[test]
+#[serial]
 fn warn_with_line_number_no_crash() {
     unsafe {
         currentLine = 42;
@@ -32,22 +37,26 @@ fn warn_with_line_number_no_crash() {
 }
 
 #[test]
+#[serial]
 fn error_basic_no_crash() {
     unsafe { lo3_error(cstr("test error").as_ptr(), cstr("ctx").as_ptr()); }
 }
 
 #[test]
+#[serial]
 fn error_null_context_no_crash() {
     unsafe { lo3_error(cstr("no ctx error").as_ptr(), std::ptr::null()); }
 }
 
 #[test]
+#[serial]
 fn error_empty_message_no_crash() {
     // Empty msg triggers lo3_warn fallback — must not crash.
     unsafe { lo3_error(cstr("").as_ptr(), cstr("ctx").as_ptr()); }
 }
 
 #[test]
+#[serial]
 fn error_with_line_number_no_crash() {
     unsafe {
         currentLine = 7;

--- a/test/unit/test_parsing.c
+++ b/test/unit/test_parsing.c
@@ -12,9 +12,21 @@
 #include "../../src/internal/core.h"
 #include <string.h>
 #include <stdio.h>
+#include <stdlib.h>
 
 // openFile defined in main.c — stub for tests
 FILE *openFile = NULL;
+
+// Build a temp-file path portably (#154): /tmp does not exist on stock Windows,
+// so pick the first temp dir the environment offers and fall back to /tmp.
+static const char *tmp_path(const char *name, char *buf, size_t size) {
+    const char *dir = getenv("TMPDIR");
+    if (!dir) dir = getenv("TEMP");
+    if (!dir) dir = getenv("TMP");
+    if (!dir) dir = "/tmp";
+    snprintf(buf, size, "%s/%s", dir, name);
+    return buf;
+}
 
 void setUp(void) {
     var_init();
@@ -73,11 +85,15 @@ void test_pars_resv_string_single_char(void) {
     TEST_ASSERT_EQUAL_STRING("x", (const char *)v.value.string);
 }
 
-void test_pars_resv_string_points_into_buffer(void) {
-    // pars_resv returns &type[1] for strings — pointer into the input buffer
+void test_pars_resv_string_returns_copy(void) {
+    // pars_resv strdup()s strings — the result must survive the input buffer
     char arg[64] = "_world";
     lo3_val v = pars_resv(arg);
-    TEST_ASSERT_EQUAL_PTR(&arg[1], v.value.string);
+    TEST_ASSERT_NOT_NULL(v.value.string);
+    TEST_ASSERT_NOT_EQUAL(&arg[1], (const char *)v.value.string);
+    memset(arg, 0, sizeof(arg));
+    TEST_ASSERT_EQUAL_STRING("world", (const char *)v.value.string);
+    free((void *)v.value.string);
 }
 
 // --- pars_resv: TYPE_var (%) ---
@@ -125,34 +141,38 @@ void test_pars_resv_array_resolves_num(void) {
 // --- pars_isFileValid ---
 
 void test_pars_isFileValid_valid_lo3_file(void) {
-    const char *path = "/tmp/lo3_unit_test_valid.lo3";
+    char path[512];
+    tmp_path("lo3_unit_test_valid.lo3", path, sizeof(path));
     FILE *tmp = fopen(path, "w");
     TEST_ASSERT_NOT_NULL(tmp);
     fclose(tmp);
 
     FILE *f = NULL;
-    int r = pars_isFileValid((char *)path, &f);
+    int r = pars_isFileValid(path, &f);
     TEST_ASSERT_EQUAL_INT(0, r);
     if (f) fclose(f);
     remove(path);
 }
 
 void test_pars_isFileValid_wrong_extension(void) {
-    const char *path = "/tmp/lo3_unit_test_wrong.txt";
+    char path[512];
+    tmp_path("lo3_unit_test_wrong.txt", path, sizeof(path));
     FILE *tmp = fopen(path, "w");
     TEST_ASSERT_NOT_NULL(tmp);
     fclose(tmp);
 
     FILE *f = NULL;
-    int r = pars_isFileValid((char *)path, &f);
+    int r = pars_isFileValid(path, &f);
     TEST_ASSERT_EQUAL_INT(-1, r);
     if (f) fclose(f);
     remove(path);
 }
 
 void test_pars_isFileValid_nonexistent_file(void) {
+    char path[512];
+    tmp_path("lo3_does_not_exist_at_all.lo3", path, sizeof(path));
     FILE *f = NULL;
-    int r = pars_isFileValid("/tmp/lo3_does_not_exist_at_all.lo3", &f);
+    int r = pars_isFileValid(path, &f);
     TEST_ASSERT_EQUAL_INT(-1, r);
 }
 
@@ -191,7 +211,7 @@ int main(void) {
 
     RUN_TEST(test_pars_resv_string_basic);
     RUN_TEST(test_pars_resv_string_single_char);
-    RUN_TEST(test_pars_resv_string_points_into_buffer);
+    RUN_TEST(test_pars_resv_string_returns_copy);
 
     RUN_TEST(test_pars_resv_var_resolves_num_var);
     RUN_TEST(test_pars_resv_var_resolves_string_var);


### PR DESCRIPTION
## Summary

Works through the [META] test-suite issue #213. Seven of the nine child issues are fixed here; the remaining two are accounted for below.

Closes #153, closes #154, closes #155, closes #180, closes #182, closes #183, closes #187.
Part of #213.

### test/syntax (`0ce9786`)
- Runner appends `.exe` on Windows (#154)
- `.expected` files and interpreter stdout are both normalized to LF before comparing; `.gitattributes` pins `*.expected` / `*.lo3` to `eol=lf` (#182)
- Optional `<test>.exitcode` files declare the expected exit code, default 0 (#153). `24_ret_bad_stops.exitcode` is deliberately **not** added yet: the interpreter still exits 0 on `#1` (#125 unfixed) — verified empirically. Once #125 lands, add the file with content `1`.

### CI (`0689878`)
- `compile-check.yml` now also triggers on **push** to `main` / `future/**` (#155)
- Single `build-and-test` job: cmake build → `ctest` → `cargo test -- --test-threads=1` → real per-file syntax runner (#155)
- The `#include`/cpp aggregate hack is deleted — the first `#0` used to terminate every test after it (#187). No `continue-on-error` anywhere.

### test/unit (`b872815`)
- Rust tests: `serial_test` + `#[serial]` on every test touching C globals, replacing the `RUST_TEST_THREADS=1` crutch; `with_cf!` got a teardown and `reset_cf()` frees the strdup'd label names; `ARRAY_SIZE` mirror corrected 254 → 256 to match `control-flow.h` (#180)
- `test_parsing.c` builds temp paths from `TMPDIR`/`TEMP`/`TMP` instead of hardcoded `/tmp`; `build.rs` compiles `lo3-getLine.c` so the crate links on Windows (#154)
- `test_pars_resv_string_points_into_buffer` → `_returns_copy`: `pars_resv` strdup()s strings nowadays, so the old pointer-equality assert failed deterministically — CI just never ran it (#155)

### test/run_tests.py (`31502fb`)
- `shutil.which` guards for cargo/cmake/ctest; missing tools produce a SKIP state in the summary instead of a `FileNotFoundError` traceback; stages reordered syntax → C → Rust (#183)

## Not in this PR

- **#152** — verified already fixed: `%63s` padding is gone from `src/execute.c` and all 27 `.expected` files are unpadded (fbe91b4). Can be closed manually.
- **#133** — affects `future/v0.3.0` only (test files there call `exec_*`/`pars_dispatch` with extra args); not fixable from a `main`-based branch, needs its own PR against that branch.

## Test plan

Full local run on Windows 11 (MinGW/Ninja): `python test/run_tests.py` →
- Syntax tests: **27/27 PASS**
- C unit tests (ctest): **2/2 PASS**
- Rust unit tests: **92/92 PASS**

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Improved cross-platform test support, including Windows executables and platform-appropriate temporary paths.
  - Syntax tests now support expected non-zero exit codes and provide clearer failure diagnostics.
  - Parsing now safely returns an independent copy of reserved strings.
  - Improved cleanup and isolation for tests involving shared state.

- **Chores**
  - Streamlined automated build and test checks.
  - Tests can skip unavailable toolchains instead of failing unexpectedly.
  - Added handling for generated test files and build artifacts.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->